### PR TITLE
[keycloak] Switch back to using env var PROXY_ADDRESS_FORWARDING

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.11.1
+version: 4.11.2
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -56,7 +56,7 @@ Parameter | Description | Default
 `keycloak.existingSecretKey` |  The key in `keycloak.existingSecret` that stores the admin password | `password`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraContainers` | Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy. Passed through the `tpl` function and thus to be configured a string | `""`
-`keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` function and thus to be configured a string | `""`
+`keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` function and thus to be configured a string | `PROXY_ADDRESS_FORWARDING="true"`
 `keycloak.extraVolumeMounts` | Add additional volumes mounts, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraVolumes` | Add additional volumes, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraPorts` | Add additional ports, e. g. for custom admin console port. Passed through the `tpl` function and thus to be configured a string | `""`
@@ -79,7 +79,6 @@ Parameter | Description | Default
 `keycloak.readinessProbe.timeoutSeconds` | Readiness Probe `timeoutSeconds` | `1`
 `keycloak.cli.nodeIdentifier` | WildFly CLI script for setting the node identifier | See `values.yaml`
 `keycloak.cli.logging` | WildFly CLI script for logging configuration | See `values.yaml`
-`keycloak.cli.reverseProxy` | WildFly CLI script for reverse proxy configuration | See `values.yaml`
 `keycloak.cli.ha` | Settings for HA setups | See `values.yaml`
 `keycloak.cli.custom` | Additional custom WildFly CLI script | `""`
 `keycloak.service.annotations` | Annotations for the Keycloak service | `{}`

--- a/charts/keycloak/scripts/reverse-proxy.cli
+++ b/charts/keycloak/scripts/reverse-proxy.cli
@@ -1,3 +1,0 @@
-/socket-binding-group=standard-sockets/socket-binding=proxy-https:add(port=443)
-/subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=redirect-socket, value=proxy-https)
-/subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=proxy-address-forwarding, value=true)

--- a/charts/keycloak/templates/configmap.yaml
+++ b/charts/keycloak/templates/configmap.yaml
@@ -42,8 +42,6 @@ data:
 
 {{ tpl .logging $ | indent 4 }}
 
-{{ tpl .reverseProxy $ | indent 4 }}
-
 {{ tpl .datasource $ | indent 4 }}
 
 {{- if $highAvailability }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -67,6 +67,8 @@ keycloak:
 
   ## Allows the specification of additional environment variables for Keycloak
   extraEnv: |
+    - name: PROXY_ADDRESS_FORWARDING
+      value: "true"
     # - name: KEYCLOAK_LOGLEVEL
     #   value: DEBUG
     # - name: WILDFLY_LOGLEVEL


### PR DESCRIPTION
Proxy address forwarding was directly enabled via CLI but
missed one location. This commit, thus, switches back to
using the environment variable as meant by the Keycloak
Docker image and set the envs var to 'true' by default to
keep the existing behavior.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>