### PR TITLE
[keycloak] Disable service links by default

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.11.1
+version: 4.12.0
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.11.2
+version: 4.12.0
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -69,6 +69,7 @@ Parameter | Description | Default
 `keycloak.podLabels` | Extra labels to add to pod | `{}`
 `keycloak.podAnnotations` | Extra annotations to add to pod | `{}`
 `keycloak.hostAliases` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]`
+`keycloak.enableServiceLinks` | Indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links | `false`
 `keycloak.securityContext` | Security context for the pod | `{runAsUser: 1000, fsGroup: 1000, runAsNonRoot: true}`
 `keycloak.preStartScript` | Custom script to run before Keycloak starts up | ``
 `keycloak.lifecycleHooks` | Container lifecycle hooks. Passed through the `tpl` function and thus to be configured a string | ``

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
         release: "{{ .Release.Name }}"
       {{- if .Values.keycloak.podLabels }}
 {{ toYaml .Values.keycloak.podLabels | indent 8 }}
-      {{- end }}        
+      {{- end }}
 {{- if .Values.keycloak.podAnnotations }}
       annotations:
 {{ toYaml .Values.keycloak.podAnnotations | indent 8 }}
@@ -37,6 +37,7 @@ spec:
       hostAliases:
 {{ toYaml . | indent 8 }}
 {{- end }}
+      enableServiceLinks: {{ .Values.keycloak.enableServiceLinks }}
       securityContext:
 {{ toYaml .Values.keycloak.securityContext | indent 8 }}
     {{- with .Values.keycloak.image.pullSecrets }}
@@ -148,7 +149,7 @@ spec:
     {{- end }}
 {{- if .Values.keycloak.priorityClassName }}
       priorityClassName: {{ .Values.keycloak.priorityClassName }}
-{{- end }}      
+{{- end }}
       terminationGracePeriodSeconds: 60
       volumes:
         - name: scripts

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -26,6 +26,8 @@ keycloak:
   #    hostnames:
   #      - "my.host.com"
 
+  enableServiceLinks: false
+
   securityContext:
     runAsUser: 1000
     fsGroup: 1000


### PR DESCRIPTION
This avoids environment variables for other services in the
same namespace being injected into the containers which
could issues with the way the Keycloak Docker image handles
environment variables for accessing the database.

Fixes: #9
Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>