### PR TITLE
[keycloak] Use existing secret for tests when it's also used for deployment

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.14.0
+version: 4.14.1
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/test/test-pod.yaml
+++ b/charts/keycloak/templates/test/test-pod.yaml
@@ -18,7 +18,7 @@ spec:
     - name: {{ .Chart.Name }}-test
       image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
-      securityContext:  
+      securityContext:
 {{ toYaml .Values.test.containerSecurityContext | indent 8 }}
       command:
         - python3
@@ -29,7 +29,11 @@ spec:
         - name: KEYCLOAK_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if .Values.keycloak.existingSecret }}
+              name: {{ .Values.keycloak.existingSecret }}
+            {{- else }}
               name: {{ template "keycloak.fullname" . }}-http
+            {{- end }}
               key: password
       volumeMounts:
         - name: tests


### PR DESCRIPTION
https://github.com/helm/charts/pull/12795 enabled using an existing secret for the `admin` user of Keycloak. However, the chart tests weren't updated and they still try to use the secret that the chart always used to create.

This PR changes the chart tests so that they use the existing secret specified by the user if it was also used to deploy the chart.