### PR TITLE
[keycloak] Add Prometheus Operator support

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 6.0.4
+version: 6.1.0
 appVersion: 7.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -401,7 +401,8 @@ It is possible to monitor Keycloak with Prometheus through the use of plugins su
       emptyDir: {}
 ```
 
-You can then either configure Prometheus to scrape the `/auth/realms/master/metrics` path on the normal HTTP port of JBoss, or if you are using the [Prometheus Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) you can enable prometheus.operator.enabled in `values.yaml` and use the example configuration. If you are using Prometheus Operator for configuring Prometheus Rules, the chart also supports this; see prometheus.operator.prometheusRules in `values.yaml` for more details.
+You can then either configure Prometheus to scrape the `/auth/realms/master/metrics` path on the normal HTTP port of JBoss, or if you use the [Prometheus Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator) you can enable `prometheus.operator.enabled` in `values.yaml` and use the example configuration.
+If you are using Prometheus Operator for configuring Prometheus Rules, the chart also supports this; see `prometheus.operator.prometheusRules` in `values.yaml` for more details.
 
 ## Why StatefulSet?
 

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -127,6 +127,14 @@ Parameter | Description | Default
 `test.image.pullPolicy` | Test image pull policy | `IfNotPresent`
 `test.securityContext` | Security context for the test pod. Every container running in the pod will inherit this security context. This might be relevant when other components of the environment inject additional containers into the running pod (service meshs are the most prominent example for this) | `{fsGroup: 1000}`
 `test.containerSecurityContext` | Security context for containers running in the test pod. Will not be inherited by additionally injected containers | `{runAsUser: 1000, runAsNonRoot: true}`
+`prometheus.operator.enabled` | Enable the Prometheus Operator features of the chart | `false`
+`prometheus.operator.serviceMonitor.selector` | Labels to add to the Prometheus Operator ServiceMonitor depending on your Operator configuration | `release: prometheus`
+`prometheus.operator.serviceMonitor.interval` | How often Prometheus should poll the metrics endpoint | `10s`
+`prometheus.operator.serviceMonitor.scrapeTimeout` | How long the Prometheus metrics endpoint timeout should be | `10s`
+`prometheus.operator.serviceMonitor.path` | The path of the Prometheus metrics endpoint on Keycloak | `/auth/realms/master/metrics`
+`prometheus.operator.prometheusRules.enabled` | Whether to create Prometheus Operator PrometheusRules object | `false`
+`prometheus.operator.prometheusRules.selector` | Labels to add to the Prometheus Operator PrometheusRules object depending on your Operator configuration | `{app: prometheus-operator", release: prometheus}`
+`prometheus.operator.prometheusRules.rules` | The Prometheus Operator rules to configure | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/keycloak/templates/prometheusrules.yaml
+++ b/charts/keycloak/templates/prometheusrules.yaml
@@ -2,15 +2,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "keycloak.fullname" . }}
-  {{- if .Values.prometheus.operator.prometheusRules.namespace }}
-  namespace: {{ .Values.prometheus.operator.prometheusRules.namespace }}
-  {{- end }}
+  name: {{ include "keycloak.fullname" . }}
   labels:
-{{ toYaml .Values.prometheus.operator.prometheusRules.selector | indent 4 }}
+    {{- include "keycloak.commonLabels" . | nindent 4 }}
+    {{ toYaml .Values.prometheus.operator.prometheusRules.selector | nindent 4 }}
 spec:
   groups:
-  - name: {{ template "keycloak.fullname" . }}
+  - name: {{ include "keycloak.fullname" . }}
     rules:
-{{ toYaml .Values.prometheus.operator.prometheusRules.rules | indent 6 }}
+      {{ toYaml .Values.prometheus.operator.prometheusRules.rules | nindent 6 }}
 {{- end }}

--- a/charts/keycloak/templates/prometheusrules.yaml
+++ b/charts/keycloak/templates/prometheusrules.yaml
@@ -4,11 +4,11 @@ kind: PrometheusRule
 metadata:
   name: {{ include "keycloak.fullname" . }}
   labels:
-    {{- include "keycloak.commonLabels" . | nindent 4 }}
+    {{- include "keycloak.selectorLabels" . | nindent 4 }}
     {{ toYaml .Values.prometheus.operator.prometheusRules.selector | nindent 4 }}
 spec:
   groups:
   - name: {{ include "keycloak.fullname" . }}
     rules:
-      {{ toYaml .Values.prometheus.operator.prometheusRules.rules | nindent 6 }}
+      {{- toYaml .Values.prometheus.operator.prometheusRules.rules | nindent 6 }}
 {{- end }}

--- a/charts/keycloak/templates/prometheusrules.yaml
+++ b/charts/keycloak/templates/prometheusrules.yaml
@@ -1,0 +1,16 @@
+{{ if and (.Values.prometheus.operator.prometheusRules.enabled) (.Values.prometheus.operator.prometheusRules.rules) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "keycloak.fullname" . }}
+  {{- if .Values.prometheus.operator.prometheusRules.namespace }}
+  namespace: {{ .Values.prometheus.operator.prometheusRules.namespace }}
+  {{- end }}
+  labels:
+{{ toYaml .Values.prometheus.operator.prometheusRules.selector | indent 4 }}
+spec:
+  groups:
+  - name: {{ template "keycloak.fullname" . }}
+    rules:
+{{ toYaml .Values.prometheus.operator.prometheusRules.rules | indent 6 }}
+{{- end }}

--- a/charts/keycloak/templates/prometheusrules.yaml
+++ b/charts/keycloak/templates/prometheusrules.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "keycloak.fullname" . }}
   labels:
     {{- include "keycloak.selectorLabels" . | nindent 4 }}
-    {{ toYaml .Values.prometheus.operator.prometheusRules.selector | nindent 4 }}
+    {{- toYaml .Values.prometheus.operator.prometheusRules.selector | nindent 4 }}
 spec:
   groups:
   - name: {{ include "keycloak.fullname" . }}

--- a/charts/keycloak/templates/service-headless.yaml
+++ b/charts/keycloak/templates/service-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "keycloak.fullname" . }}-headless
   labels:
     {{- include "keycloak.commonLabels" . | nindent 4 }}
+    service: headless
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/keycloak/templates/service-http.yaml
+++ b/charts/keycloak/templates/service-http.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- with $service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    service: http
 spec:
   type: {{ $service.type }}
   ports:

--- a/charts/keycloak/templates/servicemonitor.yaml
+++ b/charts/keycloak/templates/servicemonitor.yaml
@@ -9,14 +9,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "keycloak.commonLabels" . | nindent 6 }}
+      {{- include "keycloak.selectorLabels" . | nindent 6 }}
       service: http
   endpoints:
     - port: http
       path: {{ .Values.prometheus.operator.serviceMonitor.path }}
       interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}
-      {{- if .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
       {{- end }}
 {{ end }}
 

--- a/charts/keycloak/templates/servicemonitor.yaml
+++ b/charts/keycloak/templates/servicemonitor.yaml
@@ -2,24 +2,21 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "keycloak.fullname" . }}
-  {{- if .Values.prometheus.operator.serviceMonitor.namespace }}
-  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
-  {{- end }}
+  name: {{ include "keycloak.fullname" . }}
   labels:
-{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+    {{- include "keycloak.commonLabels" . | nindent 4 }}
+    {{ toYaml .Values.prometheus.operator.serviceMonitor.selector | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "keycloak.name" . }}
-      release: "{{ .Release.Name }}"
+      {{- include "keycloak.commonLabels" . | nindent 6 }}
       service: http
   endpoints:
-  - port: http
-    path: {{ .Values.prometheus.operator.serviceMonitor.path }}
-    interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}
-  {{- if .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
-  {{- end }}
+    - port: http
+      path: {{ .Values.prometheus.operator.serviceMonitor.path }}
+      interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}
+      {{- if .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
+      {{- end }}
 {{ end }}
 

--- a/charts/keycloak/templates/servicemonitor.yaml
+++ b/charts/keycloak/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "keycloak.fullname" . }}
   labels:
     {{- include "keycloak.commonLabels" . | nindent 4 }}
-    {{ toYaml .Values.prometheus.operator.serviceMonitor.selector | nindent 4 }}
+    {{- toYaml .Values.prometheus.operator.serviceMonitor.selector | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/keycloak/templates/servicemonitor.yaml
+++ b/charts/keycloak/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{ if and .Values.prometheus.operator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "keycloak.fullname" . }}
+  {{- if .Values.prometheus.operator.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "keycloak.name" . }}
+      release: "{{ .Release.Name }}"
+      service: http
+  endpoints:
+  - port: http
+    path: {{ .Values.prometheus.operator.serviceMonitor.path }}
+    interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}
+  {{- if .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
+  {{- end }}
+{{ end }}
+

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -339,10 +339,7 @@ prometheus:
     enabled: false
 
     serviceMonitor:
-      ## Namespace in which to install the ServiceMonitor. Defaults to the same as everything else.
-      # namespace: monitoring
-
-      ## Labels to add to the ServiceMonitor so it is picked up by the operator.
+      ## Additional labels to add to the ServiceMonitor so it is picked up by the operator.
       ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release.
       selector:
         release: prometheus
@@ -360,10 +357,7 @@ prometheus:
       ## Add Prometheus Rules?
       enabled: false
 
-      ## Namespace in which to install the PrometheusRule. Defaults to the same as everything else.
-      # namespace: monitoring
-
-      ## Labels to add to the PrometheusRule so it is picked up by the operator.
+      ## Additional labels to add to the PrometheusRule so it is picked up by the operator.
       ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release and 'app: prometheus-operator'
       selector:
         app: prometheus-operator

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -332,3 +332,56 @@ test:
   containerSecurityContext:
     runAsUser: 1000
     runAsNonRoot: true
+
+prometheus:
+  operator:
+    ## Are you using Prometheus Operator?
+    enabled: false
+
+    serviceMonitor:
+      ## Namespace in which to install the ServiceMonitor. Defaults to the same as everything else.
+      # namespace: monitoring
+
+      ## Labels to add to the ServiceMonitor so it is picked up by the operator.
+      ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release.
+      selector:
+        release: prometheus
+
+      ## Interval at which Prometheus scrapes metrics
+      interval: 10s
+
+      ## Timeout at which Prometheus timeouts scrape run
+      scrapeTimeout: 10s
+
+      ## The path to scrape
+      path: /auth/realms/master/metrics
+
+    prometheusRules:
+      ## Add Prometheus Rules?
+      enabled: false
+
+      ## Namespace in which to install the PrometheusRule. Defaults to the same as everything else.
+      # namespace: monitoring
+
+      ## Labels to add to the PrometheusRule so it is picked up by the operator.
+      ## If using the [Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator) this is the name of the Helm release and 'app: prometheus-operator'
+      selector:
+        app: prometheus-operator
+        release: prometheus
+
+      ## Some example rules.
+      rules: {}
+      #  - alert: keycloak-IngressHigh5xxRate
+      #    annotations:
+      #      message: The percentage of 5xx errors for keycloak over the last 5 minutes is over 1%.
+      #    expr: (sum(rate(nginx_ingress_controller_response_duration_seconds_count{exported_namespace="mynamespace",ingress="mynamespace-keycloak",status=~"5[0-9]{2}"}[1m]))/sum(rate(nginx_ingress_controller_response_duration_seconds_count{exported_namespace="mynamespace",ingress="mynamespace-keycloak"}[1m])))*100 > 1
+      #    for: 5m
+      #    labels:
+      #      severity: warning
+      #  - alert: keycloak-IngressHigh5xxRate
+      #    annotations:
+      #      message: The percentage of 5xx errors for keycloak over the last 5 minutes is over 5%.
+      #    expr: (sum(rate(nginx_ingress_controller_response_duration_seconds_count{exported_namespace="mynamespace",ingress="mynamespace-keycloak",status=~"5[0-9]{2}"}[1m]))/sum(rate(nginx_ingress_controller_response_duration_seconds_count{exported_namespace="mynamespace",ingress="mynamespace-keycloak"}[1m])))*100 > 5
+      #    for: 5m
+      #    labels:
+      #      severity: critical


### PR DESCRIPTION
Adds prometheus operator support for plugins such as https://github.com/aerogear/keycloak-metrics-spi