### PR TITLE
[keycloak] Depedency postresql secret mention postgresql-password as …

### DIFF
--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Create environment variables for database configuration.
   valueFrom:
     secretKeyRef:
       name: {{ template "keycloak.postgresql.fullname" . }}
-      key: postgres-password
+      key: postgresql-password
 {{- else }}
 - name: DB_VENDOR
   value: {{ .Values.keycloak.persistence.dbVendor | quote }}


### PR DESCRIPTION
[keycloak] Depedency postresql secret mention postgresql-password as key but the template wrongly mention key as postgres-password

It should adhere to postgresql naming convention rather than postgres.

Signed-off-by: Vijender Singh Thakur <gsvijendert@gmail.com>