### PR TITLE
[Keycloak] Wrong secret key "postgres-password" used in template.The …

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.16.0
+version: 4.16.1
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -94,7 +94,7 @@ Create environment variables for database configuration.
   valueFrom:
     secretKeyRef:
       name: {{ template "keycloak.postgresql.fullname" . }}
-      key: postgres-password
+      key: postgresql-password
 {{- else }}
 - name: DB_VENDOR
   value: {{ .Values.keycloak.persistence.dbVendor | quote }}


### PR DESCRIPTION
[Keycloak] Wrong secret key "postgres-password" used in template.The postgresql dependency secret mention key as "postgresql-password"

Updating chart version

Signed-off-by: Vijender Singh Thakur <gsvijendert@gmail.com>