### PR TITLE
[mailhog] add missing '.' to service annotation block

### DIFF
--- a/charts/mailhog/templates/service.yaml
+++ b/charts/mailhog/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "mailhog.fullname" . }}
   {{- with .Values.service.annotations }}
   annotations:
-    {{- toYaml | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "mailhog.name" . }}


### PR DESCRIPTION
add missing '.' to service annotation toYaml code to prevent error "m…ailhog/templates/service.yaml" at <toYaml>: wrong number of args for toYaml: want 1 got 0