### PR TITLE
[keycloak] Remove H2 test

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.0.0
+version: 5.0.1
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/ci/h2-values.yaml
+++ b/charts/keycloak/ci/h2-values.yaml
@@ -1,2 +1,0 @@
-keycloak:
-  password: keycloak


### PR DESCRIPTION
The test adds little value. After all H2 is not
really a suitable database. It is recreated on restarts
and does not support upgrades. However, we'd like to
enable upgrade testing which increases test times
substantially and does not work with H2.

Signed-off-by: Reinhard Naegele <unguiculus@gmail.com>