### PR TITLE
Fix keycloak pods label filtering

### DIFF
--- a/charts/keycloak/templates/NOTES.txt
+++ b/charts/keycloak/templates/NOTES.txt
@@ -34,7 +34,7 @@ Keycloak can be accessed:
 
 {{- else if contains "ClusterIP" .Values.keycloak.service.type }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ include "keycloak.name" . }},release={{ .Release.Name }} -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use Keycloak"
   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080
 


### PR DESCRIPTION
The current version introduces an error because the pods do not have the requested label