### PR TITLE
[keycloak] Expose keycloak generated dns name as env variable (#68)

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.0.1
+version: 5.1.0
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -25,6 +25,13 @@ We truncate to 20 characters because this is used to set the node identifier in 
 {{- end -}}
 
 {{/*
+Create the service DNS name.
+*/}}
+{{- define "keycloak.serviceDnsName" -}}
+{{ include "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "keycloak.chart" -}}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -90,7 +90,9 @@ spec:
             - name: JGROUPS_DISCOVERY_PROTOCOL
               value: "dns.DNS_PING"
             - name: JGROUPS_DISCOVERY_PROPERTIES
-              value: "dns_query={{ include "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+              value: "dns_query={{ include "keycloak.serviceDnsName" . }}"
+            - name: KEYCLOAK_SERVICE_DNS_NAME
+              value: "{{ include "keycloak.serviceDnsName" . }}"
           {{- end }}
             {{- include "keycloak.dbEnvVars" . | nindent 12 }}
           {{- with .Values.keycloak.extraEnv }}


### PR DESCRIPTION
We now expose the generated DNS name of the Keycloak headless-service
via the environment variable KEYCLOAK_SERVICE_DNS_NAME.
This eases the usage of custom jgroups configurations in custom
Keycloak images.

In order to avoid code duplication we introduced a new template function
called `serviceDnsName` accessible via `keycloak.serviceDnsName`.