### PR TITLE
[keycloak] Fix bind address handling

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.1
+version: 5.1.2
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/configmap-sh.yaml
+++ b/charts/keycloak/templates/configmap-sh.yaml
@@ -12,4 +12,4 @@ data:
     set -o errexit
     set -o nounset
 
-    exec /opt/jboss/tools/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ else }} -c standalone.xml{{ end }}
+    exec /opt/jboss/tools/docker-entrypoint.sh {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ else }} -c standalone.xml{{ end }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -93,6 +93,8 @@ spec:
               value: "dns_query={{ include "keycloak.serviceDnsName" . }}"
             - name: KEYCLOAK_SERVICE_DNS_NAME
               value: "{{ include "keycloak.serviceDnsName" . }}"
+            - name: BIND
+              value: "0.0.0.0"
           {{- end }}
             {{- include "keycloak.dbEnvVars" . | nindent 12 }}
           {{- with .Values.keycloak.extraEnv }}


### PR DESCRIPTION
Drops setting the system property in favor of setting the
BIND environment variable which was added in
https://github.com/jboss-dockerfiles/keycloak/pull/151.

This does away with a duplicate entry of the system property
'-Djboss.bind.address' in the commandline.

Signed-off-by: Reinhard Naegele <unguiculus@gmail.com>