### PR TITLE
[keycloak] Revert bind address changes

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.2
+version: 5.1.1
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.1
+version: 5.1.4
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.3
+version: 5.1.2
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/configmap-sh.yaml
+++ b/charts/keycloak/templates/configmap-sh.yaml
@@ -12,4 +12,4 @@ data:
     set -o errexit
     set -o nounset
 
-    exec /opt/jboss/tools/docker-entrypoint.sh {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ else }} -c standalone.xml{{ end }}
+    exec /opt/jboss/tools/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ else }} -c standalone.xml{{ end }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -93,12 +93,8 @@ spec:
               value: "dns_query={{ include "keycloak.serviceDnsName" . }}"
             - name: KEYCLOAK_SERVICE_DNS_NAME
               value: "{{ include "keycloak.serviceDnsName" . }}"
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
             - name: BIND
-              value: "0.0.0.0 $(POD_IP)"
+              value: "0.0.0.0"
           {{- end }}
             {{- include "keycloak.dbEnvVars" . | nindent 12 }}
           {{- with .Values.keycloak.extraEnv }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -93,8 +93,6 @@ spec:
               value: "dns_query={{ include "keycloak.serviceDnsName" . }}"
             - name: KEYCLOAK_SERVICE_DNS_NAME
               value: "{{ include "keycloak.serviceDnsName" . }}"
-            - name: BIND
-              value: "0.0.0.0"
           {{- end }}
             {{- include "keycloak.dbEnvVars" . | nindent 12 }}
           {{- with .Values.keycloak.extraEnv }}


### PR DESCRIPTION
The bind address changes had been done in order to remove a warning from the logs which comes from WildFly but isn't really relevant for Keycloak. However, the change resulted in port-forwarding no longer to be possible. 

We were trying to set the `BIND` environment variable to `0.0.0.0` and the local IP so that port-forwarding should still possible and clustering would continue working. The `docker-entrypoint.sh` scripts suggests this is supported adding the same system property multiple times (https://github.com/jboss-dockerfiles/keycloak/pull/156). However, this is not supported in Java. The last one wins. The script is buggy here.

Fixes: #76