### PR TITLE
tls hosts should be quoted

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.5
+version: 5.1.6
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   {{- range $ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}


### PR DESCRIPTION
they should be quoted to avoid issues on wildcard characters

actually we have issue with our wildcard chars: error parsing template.yml: error converting YAML to JSON: yaml: line 29: did not find expected alphabetic or numeric character

current output
```
spec:
  tls:
    - hosts:
        - *.development.example.com
```

desired output
```
spec:
  tls:
    - hosts:
        - '*.development.example.com'
```