### PR TITLE
Keycloak: ingress tls secret optional

### DIFF
--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -21,7 +21,9 @@ spec:
       {{- range .hosts }}
         - {{ . }}
       {{- end }}
+{{- if .secretName }}
       secretName: {{ .secretName }}
+{{- end }}
   {{- end }}
 {{- end }}
   rules:


### PR DESCRIPTION
There are cases where a secret name in the ingress's tls section is redundant, e.g. when you're using the nginx ingress controller with a default tls secret setting, which will be applied in this case.

So this PR makes the corresponding .secretName field in values.yaml optional.