### PR TITLE
Customizable liveness/readiness probes

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.7
+version: 6.0.0
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -79,10 +79,8 @@ Parameter | Description | Default
 `keycloak.startupScripts` | Custom startup scripts to run before Keycloak starts up | `[]`
 `keycloak.lifecycleHooks` | Container lifecycle hooks. Passed through the `tpl` function and thus to be configured a string | ``
 `keycloak.extraArgs` | Additional arguments to the start command | ``
-`keycloak.livenessProbe.initialDelaySeconds` | Liveness Probe `initialDelaySeconds` | `120`
-`keycloak.livenessProbe.timeoutSeconds` | Liveness Probe `timeoutSeconds` | `5`
-`keycloak.readinessProbe.initialDelaySeconds` | Readiness Probe `initialDelaySeconds` | `30`
-`keycloak.readinessProbe.timeoutSeconds` | Readiness Probe `timeoutSeconds` | `1`
+`keycloak.livenessProbe` | Liveness probe configuration. Passed through the `tpl` function and thus to be configured as string | See `values.yaml`
+`keycloak.readinessProbe` | Readiness probe configuration. Passed through the `tpl` function and thus to be configured as string | See `values.yaml`
 `keycloak.cli.enabled` | Set to `false` if no CLI changes should be performed by the chart | `true`
 `keycloak.cli.nodeIdentifier` | WildFly CLI script for setting the node identifier | See `values.yaml`
 `keycloak.cli.logging` | WildFly CLI script for logging configuration | See `values.yaml`
@@ -145,6 +143,8 @@ It is used for the following values:
 * `keycloak.affinity`
 * `keycloak.extraVolumeMounts`
 * `keycloak.extraVolumes`
+* `keycloak.livenessProbe`
+* `keycloak.readinessProbe`
 
 It is important that these values be configured as strings.
 Otherwise, installation will fail. See example for Google Cloud Proxy or default affinity configuration in `values.yaml`.
@@ -372,6 +372,30 @@ Additionally, we get stable values for `jboss.node.name` which can be advantageo
 The headless service that governs the StatefulSet is used for DNS discovery.
 
 ## Upgrading
+
+### From chart versions < 6.0.0
+
+Version 6.0.0 changes the way readiness and liveness probes are configured.
+Now both readiness and liveness probes are configured as strings that are then passed through the `tpl` function.
+This allows for greater customizability of the readiness and liveness probes.
+
+The defaults are unchanged, but since 6.0.0 configured as follows:
+
+```yaml
+livenessProbe: |
+  httpGet:
+    path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
+    port: http
+  initialDelaySeconds: 120
+  timeoutSeconds: 5
+
+readinessProbe: |
+  httpGet:
+    path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 1
+```
 
 ### From chart versions < 5.0.0
 

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -125,18 +125,14 @@ spec:
           {{- with .Values.keycloak.extraPorts }}
             {{- tpl . $ | nindent 12 }}
           {{- end }}
+          {{- with .Values.keycloak.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
-              port: http
-            initialDelaySeconds: {{ .Values.keycloak.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.keycloak.livenessProbe.timeoutSeconds }}
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.keycloak.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
-              port: http
-            initialDelaySeconds: {{ .Values.keycloak.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.keycloak.readinessProbe.timeoutSeconds }}
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.keycloak.resources | nindent 12 }}
       {{- with .Values.keycloak.extraContainers }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -135,10 +135,16 @@ keycloak:
   ## Extra Annotations to be added to pod
   podAnnotations: {}
 
-  livenessProbe:
+  livenessProbe: |
+    httpGet:
+      path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
+      port: http
     initialDelaySeconds: 120
     timeoutSeconds: 5
-  readinessProbe:
+  readinessProbe: |
+    httpGet:
+      path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
+      port: http
     initialDelaySeconds: 30
     timeoutSeconds: 1
 


### PR DESCRIPTION
This PR adds ability to completely customize liveness and readiness probes.

This can be useful in cases such as described in #46 (this PR probably resolves #46).

It also allows to run Keycloak with Istio (in strict mTLS mode), which would be impossible with hard-coded `httpGet` probes (unless `rewriteAppHTTPProbe` is set to `true`, which is not always desirable).

Here is an example of how to pass probes compatible with Istio mTLS:

```
  livenessProbe:
    probe: |
      exec:
        command:
          - curl
          - -f
          - http://127.0.0.1:8080{{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/

  readinessProbe:
    probe: |
      exec:
        command:
        - curl
        - -f
        - http://127.0.0.1:8080{{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
```

The default probe values are unchanged.
