### PR TITLE
Update postgres dependency for k8s 1.16 compatibility

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.7
+version: 5.1.8
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/requirements.lock
+++ b/charts/keycloak/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.9
-digest: sha256:5f20713cf4f8f03a87b1f78d2a350c3ebde4c500b4c4740c4c7a5655e47db924
-generated: "2019-06-21T13:48:56.67213+02:00"
+  version: 6.3.9
+digest: sha256:c88e68f83c99aed3c069ab56beaac0826c92c18a2ba4c4a868f1092f9063c807
+generated: "2019-09-30T12:46:42.277291633+02:00"

--- a/charts/keycloak/requirements.yaml
+++ b/charts/keycloak/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: 5.3.9
+    version: 6.3.9
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: keycloak.persistence.deployPostgres


### PR DESCRIPTION
https://github.com/helm/charts/pull/17281 updates the stateful set apiVersion to be compatible with k8s 1.16 due to [API deprecations](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)