### PR TITLE
Make securityContext configurable for mailhog

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: 1.0.0
-version: 3.0.1
+version: 3.1.1
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: 1.0.0
-version: 3.1.1
+version: 3.1.0
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -65,6 +65,7 @@ Parameter | Description | Default
 `service.node.smtp` | SMTP port of service | `""`
 `service.nodePort.http` | If `service.type` is `NodePort` and this is non-empty, sets the http node port of the service | `""`
 `service.nodePort.smtp` | If `service.type` is `NodePort` and this is non-empty, sets the smtp node port of the service | `""`
+`securityContext` | Pod security context | `{ runAsUser: 1000, fsGroup: 1000, runAsNonRoot: true }`
 `ingress.enabled` | If `true`, an ingress is created | `false`
 `ingress.annotations` | Annotations for the ingress | `{}`
 `ingress.path` | If `true`, an ingress is created | `/`

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -22,10 +22,10 @@ spec:
         app.kubernetes.io/name: {{ include "mailhog.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- with .Values.securityContext }}
       securityContext:
-        runAsUser: 1000
-        fsGroup: 1000
-        runAsNonRoot: true
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "mailhog.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -20,6 +20,11 @@ service:
     http: ""
     smtp: ""
 
+securityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+  runAsNonRoot: true
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
Making the security context configurable makes mailhog able to run on Openshift, where the security context gets applied automatically (and actually throws errors like these: `1000 is not an allowed group spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1003220000, 1003229999]]`)

The default values are unchanged as to not break existing deployments.