### PR TITLE
[keycloak] Create new major release

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 name: keycloak
 version: 6.0.0
-appVersion: 6.0.1
+appVersion: 7.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 5.1.7
+version: 6.0.0
 appVersion: 6.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -79,10 +79,8 @@ Parameter | Description | Default
 `keycloak.startupScripts` | Custom startup scripts to run before Keycloak starts up | `[]`
 `keycloak.lifecycleHooks` | Container lifecycle hooks. Passed through the `tpl` function and thus to be configured a string | ``
 `keycloak.extraArgs` | Additional arguments to the start command | ``
-`keycloak.livenessProbe.initialDelaySeconds` | Liveness Probe `initialDelaySeconds` | `120`
-`keycloak.livenessProbe.timeoutSeconds` | Liveness Probe `timeoutSeconds` | `5`
-`keycloak.readinessProbe.initialDelaySeconds` | Readiness Probe `initialDelaySeconds` | `30`
-`keycloak.readinessProbe.timeoutSeconds` | Readiness Probe `timeoutSeconds` | `1`
+`keycloak.livenessProbe` | Liveness probe configuration. Passed through the `tpl` function and thus to be configured as string | See `values.yaml`
+`keycloak.readinessProbe` | Readiness probe configuration. Passed through the `tpl` function and thus to be configured as string | See `values.yaml`
 `keycloak.cli.enabled` | Set to `false` if no CLI changes should be performed by the chart | `true`
 `keycloak.cli.nodeIdentifier` | WildFly CLI script for setting the node identifier | See `values.yaml`
 `keycloak.cli.logging` | WildFly CLI script for logging configuration | See `values.yaml`
@@ -145,6 +143,8 @@ It is used for the following values:
 * `keycloak.affinity`
 * `keycloak.extraVolumeMounts`
 * `keycloak.extraVolumes`
+* `keycloak.livenessProbe`
+* `keycloak.readinessProbe`
 
 It is important that these values be configured as strings.
 Otherwise, installation will fail. See example for Google Cloud Proxy or default affinity configuration in `values.yaml`.
@@ -372,6 +372,30 @@ Additionally, we get stable values for `jboss.node.name` which can be advantageo
 The headless service that governs the StatefulSet is used for DNS discovery.
 
 ## Upgrading
+
+### From chart versions < 6.0.0
+
+Version 6.0.0 changes the way readiness and liveness probes are configured.
+Now both readiness and liveness probes are configured as strings that are then passed through the `tpl` function.
+This allows for greater customizability of the readiness and liveness probes.
+
+The defaults are unchanged, but since 6.0.0 configured as follows:
+
+```yaml
+livenessProbe: |
+  httpGet:
+    path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
+    port: http
+  initialDelaySeconds: 120
+  timeoutSeconds: 5
+
+readinessProbe: |
+  httpGet:
+    path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 1
+```
 
 ### From chart versions < 5.0.0
 

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -56,6 +56,8 @@ Parameter | Description | Default
 `keycloak.password` | Password for the initial Keycloak admin user (if `keycloak.existingSecret=""`). If not set, a random 10 characters password is created | `""`
 `keycloak.existingSecret` | Specifies an existing secret to be used for the admin password | `""`
 `keycloak.existingSecretKey` |  The key in `keycloak.existingSecret` that stores the admin password | `password`
+`keycloak.jgroups.discoveryProtocol` | The protocol for JGroups discovery | `dns.DNS_PING`
+`keycloak.jgroups.discoveryProperties` | Properties for JGroups discovery. Passed through the `tpl` function | `"dns_query={{ template "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraContainers` | Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` function and thus to be configured a string | `PROXY_ADDRESS_FORWARDING="true"`

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -225,7 +225,7 @@ Create your own theme and package it up into a Docker image.
 
 ```docker
 FROM busybox
-COPY my_theme /my_theme
+COPY mytheme /mytheme
 ```
 
 In combination with an `emptyDir` that is shared with the Keycloak container, configure an init container that runs your theme image and copies the theme over to the right place where Keycloak will pick it up automatically.

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -89,8 +89,10 @@ Parameter | Description | Default
 `keycloak.service.annotations` | Annotations for the Keycloak service | `{}`
 `keycloak.service.labels` | Additional labels for the Keycloak service | `{}`
 `keycloak.service.type` | The service type | `ClusterIP`
-`keycloak.service.port` | The service port | `80`
-`keycloak.service.nodePort` | The node port used if the service is of type `NodePort` | `""`
+`keycloak.service.httpPort` | The http service port | `80`
+`keycloak.service.httpsPort` | The https service port | `8443`
+`keycloak.service.httpNodePort` | The http node port used if the service is of type `NodePort` | `""`
+`keycloak.service.httpsNodePort` | The https node port used if the service is of type `NodePort` | `""`
 `keycloak.ingress.enabled` | if `true`, an ingress is created | `false`
 `keycloak.ingress.annotations` | annotations for the ingress | `{}`
 `keycloak.ingress.labels` | Additional labels for the Keycloak ingress | `{}`
@@ -409,6 +411,12 @@ keycloak:
   keycloak:
     existingSecret: '{{ .Release.Name }}-keycloak-secret'
 ```
+
+#### HTTPS Port Added
+
+The HTTPS port was added to the pod and to the services.
+As a result, service ports are now configured differently.
+
 
 ### From chart versions < 5.0.0
 

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -375,7 +375,8 @@ The headless service that governs the StatefulSet is used for DNS discovery.
 
 ### From chart versions < 6.0.0
 
-Version 6.0.0 changes the way readiness and liveness probes are configured.
+#### Changes in Probe Configuration
+
 Now both readiness and liveness probes are configured as strings that are then passed through the `tpl` function.
 This allows for greater customizability of the readiness and liveness probes.
 
@@ -395,6 +396,18 @@ readinessProbe: |
     port: http
   initialDelaySeconds: 30
   timeoutSeconds: 1
+```
+
+#### Changes in Existing Secret Configuration
+
+This can be useful if you create a secret in a parent chart and want to reference that secret.
+Applies to `keycloak.existingSecret` and `keycloak.persistence.existingSecret`.
+
+_`values.yaml` of parent chart:_
+```yaml
+keycloak:
+  keycloak:
+    existingSecret: '{{ .Release.Name }}-keycloak-secret'
 ```
 
 ### From chart versions < 5.0.0

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -48,7 +48,7 @@ Parameter | Description | Default
 `clusterDomain` | The internal Kubernetes cluster domain | `cluster.local`
 `keycloak.replicas` | The number of Keycloak replicas | `1`
 `keycloak.image.repository` | The Keycloak image repository | `jboss/keycloak`
-`keycloak.image.tag` | The Keycloak image tag | `6.0.1`
+`keycloak.image.tag` | The Keycloak image tag | `7.0.0`
 `keycloak.image.pullPolicy` | The Keycloak image pull policy | `IfNotPresent`
 `keycloak.image.pullSecrets` | Image pull secrets | `[]`
 `keycloak.basepath` | Path keycloak is hosted at | `auth`

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -69,7 +69,7 @@ Parameter | Description | Default
 `keycloak.nodeSelector` | Node labels for pod assignment | `{}`
 `keycloak.tolerations` | Node taints to tolerate | `[]`
 `keycloak.podLabels` | Extra labels to add to pod | `{}`
-`keycloak.podAnnotations` | Extra annotations to add to pod | `{}`
+`keycloak.podAnnotations` | Extra annotations to add to pod. Values are passed through the `tpl` function | `{}`
 `keycloak.hostAliases` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]`
 `keycloak.enableServiceLinks` | Indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links | `false`
 `keycloak.restartPolicy` | Pod restart policy. One of `Always`, `OnFailure`, or `Never` | `Always`

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -41,8 +41,8 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 Parameter | Description | Default
 --- | --- | ---
-`init.image.repository` | Init image repository | `alpine`
-`init.image.tag` | Init image tag | `3.9`
+`init.image.repository` | Init image repository | `busybox`
+`init.image.tag` | Init image tag | `1.31`
 `init.image.pullPolicy` | Init image pull policy | `IfNotPresent`
 `init.resources` | Pod resource requests and limits for the init container | `{}`
 `clusterDomain` | The internal Kubernetes cluster domain | `cluster.local`

--- a/charts/keycloak/ci/postgres-ha-values.yaml
+++ b/charts/keycloak/ci/postgres-ha-values.yaml
@@ -5,7 +5,7 @@ keycloak:
   podLabels:
     test-label: test-label-value
   podAnnotations:
-    test-annotation: test-annotation-value
+    test-annotation: "test-annotation-value-{{ .Release.Name }}"
 
   startupScripts:
     hello.sh: |

--- a/charts/keycloak/requirements.lock
+++ b/charts/keycloak/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.3.9
-digest: sha256:5f20713cf4f8f03a87b1f78d2a350c3ebde4c500b4c4740c4c7a5655e47db924
-generated: "2019-06-21T13:48:56.67213+02:00"
+  version: 6.3.13
+digest: sha256:4bb0449bc5cb166117da05155a863a386fc6b04cea6428f2781d675711ea40a4
+generated: "2019-10-12T21:45:14.112985+02:00"

--- a/charts/keycloak/requirements.yaml
+++ b/charts/keycloak/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: 5.3.9
+    version: 6.3.13
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: keycloak.persistence.deployPostgres

--- a/charts/keycloak/templates/NOTES.txt
+++ b/charts/keycloak/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 Keycloak can be accessed:
 
-* Within your cluster, at the following DNS name at port {{ .Values.keycloak.service.port }}:
+* Within your cluster, at the following DNS name at port {{ .Values.keycloak.service.httpPort }}:
 
   {{ include "keycloak.fullname" . }}-http.{{ .Release.Namespace }}.svc.cluster.local
 
@@ -30,7 +30,7 @@ Keycloak can be accessed:
   You can watch the status of by running 'kubectl get svc -w {{ include "keycloak.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "keycloak.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.keycloak.service.port }}
+  echo http://$SERVICE_IP:{{ .Values.keycloak.service.httpPort }}
 
 {{- else if contains "ClusterIP" .Values.keycloak.service.type }}
 

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Create the name for the Keycloak secret.
 */}}
 {{- define "keycloak.secret" -}}
 {{- if .Values.keycloak.existingSecret -}}
-  {{- .Values.keycloak.existingSecret -}}
+  {{- tpl .Values.keycloak.existingSecret $ -}}
 {{- else -}}
   {{- include "keycloak.fullname" . -}}-http
 {{- end -}}
@@ -92,7 +92,7 @@ Create the name for the database secret.
 */}}
 {{- define "keycloak.externalDbSecret" -}}
 {{- if .Values.keycloak.persistence.existingSecret -}}
-  {{- .Values.keycloak.persistence.existingSecret -}}
+  {{- tpl .Values.keycloak.persistence.existingSecret $ -}}
 {{- else -}}
   {{- include "keycloak.fullname" . -}}-db
 {{- end -}}

--- a/charts/keycloak/templates/service-headless.yaml
+++ b/charts/keycloak/templates/service-headless.yaml
@@ -10,8 +10,12 @@ spec:
   clusterIP: None
   ports:
     - name: http
-      port: {{ .Values.keycloak.service.port }}
+      port: {{ .Values.keycloak.service.httpPort }}
       targetPort: http
+      protocol: TCP
+    - name: https
+      port: {{ .Values.keycloak.service.httpsPort }}
+      targetPort: https
       protocol: TCP
   {{- if $highAvailability }}
     - name: jgroups

--- a/charts/keycloak/templates/service-http.yaml
+++ b/charts/keycloak/templates/service-http.yaml
@@ -16,10 +16,17 @@ spec:
   type: {{ $service.type }}
   ports:
     - name: http
-      port: {{ $service.port }}
+      port: {{ $service.httpPort }}
       targetPort: http
-    {{- if and (eq "NodePort" $service.type) $service.nodePort }}
-      nodePort: {{ $service.nodePort }}
+    {{- if and (eq "NodePort" $service.type) $service.httpNodePort }}
+      nodePort: {{ $service.httpNodePort }}
+    {{- end }}
+      protocol: TCP
+    - name: https
+      port: {{ $service.httpsPort }}
+      targetPort: https
+    {{- if and (eq "NodePort" $service.type) $service.httpsNodePort }}
+      nodePort: {{ $service.httpsNodePort }}
     {{- end }}
       protocol: TCP
   selector:

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -117,6 +117,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: https
+              containerPort: 8443
+              protocol: TCP
           {{- if $highAvailability }}
             - name: jgroups
               containerPort: 7600

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -90,9 +90,9 @@ spec:
               value: /secrets/{{ include "keycloak.passwordKey" . }}
           {{- if $highAvailability }}
             - name: JGROUPS_DISCOVERY_PROTOCOL
-              value: "dns.DNS_PING"
+              value: {{ .Values.keycloak.jgroups.discoveryProtocol }}
             - name: JGROUPS_DISCOVERY_PROPERTIES
-              value: "dns_query={{ include "keycloak.serviceDnsName" . }}"
+              value: {{ tpl .Values.keycloak.jgroups.discoveryProperties . }}
             - name: KEYCLOAK_SERVICE_DNS_NAME
               value: "{{ include "keycloak.serviceDnsName" . }}"
           {{- end }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -25,7 +25,9 @@ spec:
         checksum/config-sh: {{ include (print .Template.BasePath "/configmap-sh.yaml") . | sha256sum }}
         checksum/config-startup: {{ include (print .Template.BasePath "/configmap-startup.yaml") . | sha256sum }}
         {{- with .Values.keycloak.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := . }}
+        {{- printf "%s: %s" $key (tpl $value $) | nindent 8 }}
+        {{- end }}
         {{- end }}
     spec:
       {{- with .Values.keycloak.hostAliases }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -125,18 +125,14 @@ spec:
           {{- with .Values.keycloak.extraPorts }}
             {{- tpl . $ | nindent 12 }}
           {{- end }}
+          {{- with .Values.keycloak.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
-              port: http
-            initialDelaySeconds: {{ .Values.keycloak.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.keycloak.livenessProbe.timeoutSeconds }}
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.keycloak.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
-              port: http
-            initialDelaySeconds: {{ .Values.keycloak.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.keycloak.readinessProbe.timeoutSeconds }}
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.keycloak.resources | nindent 12 }}
       {{- with .Values.keycloak.extraContainers }}

--- a/charts/keycloak/templates/test/configmap-test.yaml
+++ b/charts/keycloak/templates/test/configmap-test.yaml
@@ -17,7 +17,7 @@ data:
     print('Creating PhantomJS driver...')
     driver = webdriver.PhantomJS(service_log_path='/tmp/ghostdriver.log')
 
-    base_url = 'http://{{ include "keycloak.fullname" . }}-http{{ if ne 80 (int .Values.keycloak.service.port) }}:{{ .Values.keycloak.service.port }}{{ end }}'
+    base_url = 'http://{{ include "keycloak.fullname" . }}-http{{ if ne 80 (int .Values.keycloak.service.httpPort) }}:{{ .Values.keycloak.service.httpPort }}{{ end }}'
 
     print('Opening Keycloak...')
     driver.get('{0}/auth/admin/'.format(base_url))

--- a/charts/keycloak/templates/test/pod-test.yaml
+++ b/charts/keycloak/templates/test/pod-test.yaml
@@ -26,12 +26,8 @@ spec:
         - name: KEYCLOAK_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.keycloak.existingSecret }}
-              name: {{ .Values.keycloak.existingSecret }}
-            {{- else }}
-              name: {{ include "keycloak.fullname" . }}-http
-            {{- end }}
-              key: password
+              name: {{ include "keycloak.secret" . }}
+              key: {{ include "keycloak.passwordKey" . }}
       volumeMounts:
         - name: tests
           mountPath: /tests

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -1,7 +1,7 @@
 init:
   image:
-    repository: alpine
-    tag: 3.9
+    repository: busybox
+    tag: 1.31
     pullPolicy: IfNotPresent
   resources: {}
     # limits:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -18,7 +18,7 @@ keycloak:
 
   image:
     repository: jboss/keycloak
-    tag: 6.0.1
+    tag: 7.0.0
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -207,7 +207,11 @@ keycloak:
     ## Optional static port assignment for service type NodePort.
     # nodePort: 30000
 
-    port: 80
+    httpPort: 80
+    httpNodePort: ""
+
+    httpsPort: 8443
+    httpsNodePort: ""
 
     # Optional: jGroups port for high availability clustering
     jgroupsPort: 7600

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -82,6 +82,12 @@ keycloak:
   # The key in the existing secret that stores the password
   existingSecretKey: password
 
+  ## jGroups configuration (only for HA deployment)
+  jgroups:
+    discoveryProtocol: dns.DNS_PING
+    discoveryProperties: >
+      "dns_query={{ template "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+
   ## Allows the specification of additional environment variables for Keycloak
   extraEnv: |
     - name: PROXY_ADDRESS_FORWARDING

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -139,7 +139,7 @@ keycloak:
     httpGet:
       path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
       port: http
-    initialDelaySeconds: 120
+    initialDelaySeconds: 300
     timeoutSeconds: 5
   readinessProbe: |
     httpGet:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -135,10 +135,16 @@ keycloak:
   ## Extra Annotations to be added to pod
   podAnnotations: {}
 
-  livenessProbe:
+  livenessProbe: |
+    httpGet:
+      path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
+      port: http
     initialDelaySeconds: 120
     timeoutSeconds: 5
-  readinessProbe:
+  readinessProbe: |
+    httpGet:
+      path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
+      port: http
     initialDelaySeconds: 30
     timeoutSeconds: 1
 


### PR DESCRIPTION
This PR collects a number of changes for a new major chart release.

- [x] Make JGroups discovery configurable
- [x] Update postgres dependency for k8s 1.16 compatibility
- [x] Pass pod annotation values through the tpl function
- [x] Use busybox for init container
- [x] Add https port
- [x] Increase default initial delay for liveness probe
- [x] Upgrade to release 7.0.0
- [x] Use tpl function for existing secrets
- [x] Use helper template for secret in testpod
- [x] Make liveness/readiness probes customizable

Fixes: #113 
Fixes: #115 
Fixes: #121 
