### PR TITLE
[keycloak] Add apiVersion field

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: keycloak
-version: 6.0.0
+version: 6.0.1
 appVersion: 7.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:


### PR DESCRIPTION
apiVersion field is a mandatory for Charts.yaml file [1]
Helm v2.15 and v3 now validates apiVersion and it should be v1

[1]. https://helm.sh/docs/developing_charts/#the-chart-yaml-file

Signed-off-by: Sergiy Kulanov <sergey@kulanov.org.ua>