### PR TITLE
[keycloak] Add support for reading DB_USER from a k8s Secret

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 6.0.0
+version: 7.0.0
 appVersion: 7.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -380,14 +380,15 @@ The headless service that governs the StatefulSet is used for DNS discovery.
 ## Upgrading
 
 ### From chart versions < 7.0.0
-Version 7.0.0 is a minor update - but it does break backwards-compatibility with the existing 
+Version 7.0.0 is a minor update - but it does break backwards-compatibility with the existing
 `keycloak.persistence.existingSecret` scheme.
-#### Changes in Configuring Database Credentials from an Existing Secret 
+
+#### Changes in Configuring Database Credentials from an Existing Secret
 
 Now both `DB_USER` and `DB_PASS` can be read from an existing Kubernetes Secret. This is a requirement if you are
 provisioning database credentials dynamically - either via an Operator or some secret-management engine.
 
-The variable referencing the Password Key Name has been renamed from `keycloak.persistence.existingSecretKey` 
+The variable referencing the Password Key Name has been renamed from `keycloak.persistence.existingSecretKey`
 to `keycloak.persistence.existingSecretPasswordKey`
 
 A new, optional variable for referencing the Username Key Name for populating the `DB_USER` env has been added:
@@ -395,7 +396,7 @@ A new, optional variable for referencing the Username Key Name for populating th
 
 If left unset, `DB_USER` will be populated by the `dbUser` Helm variable.
 
-###### Example configuration: 
+###### Example configuration:
 ```yaml
 keycloak:
   persistence:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -379,23 +379,21 @@ The headless service that governs the StatefulSet is used for DNS discovery.
 
 ## Upgrading
 
+
 ### From chart versions < 7.0.0
-Version 7.0.0 is a minor update - but it does break backwards-compatibility with the existing
-`keycloak.persistence.existingSecret` scheme.
+Version 7.0.0 update breaks backwards-compatibility with the existing `keycloak.persistence.existingSecret` scheme.
 
 #### Changes in Configuring Database Credentials from an Existing Secret
 
-Both `DB_USER` and `DB_PASS` are always read from a Kubernetes Secret. This is a requirement if you are
-provisioning database credentials dynamically - either via an Operator or some secret-management engine.
+Both `DB_USER` and `DB_PASS` are always read from a Kubernetes Secret.
+This is a requirement if you are provisioning database credentials dynamically - either via an Operator or some secret-management engine.
 
-The variable referencing the Password Key Name has been renamed from `keycloak.persistence.existingSecretKey`
-to `keycloak.persistence.existingSecretPasswordKey`
+The variable referencing the password key name has been renamed from `keycloak.persistence.existingSecretKey` to `keycloak.persistence.existingSecretPasswordKey`
 
-A new, optional variable for referencing the Username Key Name for populating the `DB_USER` env has been added:
+A new, optional variable for referencing the username key name for populating the `DB_USER` env has been added:
 `keycloak.persistence.existingSecretUsernameKey`.
 
-If `keycloak.persistence.existingSecret` is left unset, a new Secret will be provisioned populated with the `dbUser`
-and `dbPassword`  Helm variables.
+If `keycloak.persistence.existingSecret` is left unset, a new Secret will be provisioned populated with the `dbUser` and `dbPassword` Helm variables.
 
 ###### Example configuration:
 ```yaml

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -385,7 +385,7 @@ Version 7.0.0 is a minor update - but it does break backwards-compatibility with
 
 #### Changes in Configuring Database Credentials from an Existing Secret
 
-Now both `DB_USER` and `DB_PASS` can be read from an existing Kubernetes Secret. This is a requirement if you are
+Both `DB_USER` and `DB_PASS` are always read from a Kubernetes Secret. This is a requirement if you are
 provisioning database credentials dynamically - either via an Operator or some secret-management engine.
 
 The variable referencing the Password Key Name has been renamed from `keycloak.persistence.existingSecretKey`
@@ -394,7 +394,8 @@ to `keycloak.persistence.existingSecretPasswordKey`
 A new, optional variable for referencing the Username Key Name for populating the `DB_USER` env has been added:
 `keycloak.persistence.existingSecretUsernameKey`.
 
-If left unset, `DB_USER` will be populated by the `dbUser` Helm variable.
+If `keycloak.persistence.existingSecret` is left unset, a new Secret will be provisioned populated with the `dbUser`
+and `dbPassword`  Helm variables.
 
 ###### Example configuration:
 ```yaml

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -135,7 +135,7 @@ Create the name for the database password secret key.
 Create the name for the database password secret key - if it is defined.
 */}}
 {{- define "keycloak.dbUserKey" -}}
-{{- if .Values.keycloak.persistence.existingSecret  -}}
+{{- if .Values.keycloak.persistence.existingSecret -}}
   {{- required "missing existingSecretUsernameKey" .Values.keycloak.persistence.existingSecretUsernameKey -}}
 {{- else -}}
   username

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -90,7 +90,7 @@ Create the name for the Keycloak secret.
 {{/*
 Create the name for the database secret.
 */}}
-{{- define "keycloak.externalDbSecret" -}}
+{{- define "keycloak.dbSecretName" -}}
 {{- if .Values.keycloak.persistence.existingSecret -}}
   {{- tpl .Values.keycloak.persistence.existingSecret $ -}}
 {{- else -}}
@@ -182,7 +182,7 @@ Load the dbUser from either a Secret or directly from .Values if existingSecretU
 {{- if and .Values.keycloak.persistence.existingSecret .Values.keycloak.persistence.existingSecretUsernameKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ include "keycloak.externalDbSecret" . }}
+      name: {{ include "keycloak.dbSecretName" . }}
       key: {{ include "keycloak.dbUserKey" . | quote }}
 {{- else }}
   value: {{ .Values.keycloak.persistence.dbUser }}
@@ -190,7 +190,7 @@ Load the dbUser from either a Secret or directly from .Values if existingSecretU
 - name: DB_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "keycloak.externalDbSecret" . }}
+      name: {{ include "keycloak.dbSecretName" . }}
       key: {{ include "keycloak.dbPasswordKey" . | quote }}
 {{- end }}
 {{- end }}

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -137,9 +137,10 @@ Create the name for the database password secret key - if it is defined.
 {{- define "keycloak.dbUserKey" -}}
 {{- if and .Values.keycloak.persistence.existingSecret .Values.keycloak.persistence.existingSecretUsernameKey -}}
   {{- .Values.keycloak.persistence.existingSecretUsernameKey -}}
+{{- else -}}
+  username
 {{- end -}}
 {{- end -}}
-
 
 {{/*
 Create environment variables for database configuration.
@@ -175,10 +176,9 @@ Create environment variables for database configuration.
 - name: DB_DATABASE
   value: {{ .Values.keycloak.persistence.dbName | quote }}
 - name: DB_USER
-
-{{/*
+{{- /*
 Load the dbUser from either a Secret or directly from .Values if existingSecretUsernameKey is not set.
-*/}}
+*/ -}}
 {{- if and .Values.keycloak.persistence.existingSecret .Values.keycloak.persistence.existingSecretUsernameKey }}
   valueFrom:
     secretKeyRef:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -176,17 +176,10 @@ Create environment variables for database configuration.
 - name: DB_DATABASE
   value: {{ .Values.keycloak.persistence.dbName | quote }}
 - name: DB_USER
-{{- /*
-Load the dbUser from either a Secret or directly from .Values if existingSecretUsernameKey is not set.
-*/ -}}
-{{- if and .Values.keycloak.persistence.existingSecret .Values.keycloak.persistence.existingSecretUsernameKey }}
   valueFrom:
     secretKeyRef:
       name: {{ include "keycloak.dbSecretName" . }}
       key: {{ include "keycloak.dbUserKey" . | quote }}
-{{- else }}
-  value: {{ .Values.keycloak.persistence.dbUser }}
-{{- end }}
 - name: DB_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -135,8 +135,8 @@ Create the name for the database password secret key.
 Create the name for the database password secret key - if it is defined.
 */}}
 {{- define "keycloak.dbUserKey" -}}
-{{- if and .Values.keycloak.persistence.existingSecret .Values.keycloak.persistence.existingSecretUsernameKey -}}
-  {{- .Values.keycloak.persistence.existingSecretUsernameKey -}}
+{{- if .Values.keycloak.persistence.existingSecret  -}}
+  {{- required "missing existingSecretUsernameKey" .Values.keycloak.persistence.existingSecretUsernameKey -}}
 {{- else -}}
   username
 {{- end -}}

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -124,8 +124,8 @@ Create the name for the password secret key.
 Create the name for the database password secret key.
 */}}
 {{- define "keycloak.dbPasswordKey" -}}
-{{- if .Values.keycloak.persistence.existingSecret -}}
-  {{- required "missing existingSecretPasswordKey" .Values.keycloak.persistence.existingSecretPasswordKey -}}
+{{- if and .Values.keycloak.persistence.existingSecret .Values.keycloak.persistence.existingSecretPasswordKey -}}
+  {{- .Values.keycloak.persistence.existingSecretPasswordKey -}}
 {{- else -}}
   password
 {{- end -}}
@@ -135,8 +135,8 @@ Create the name for the database password secret key.
 Create the name for the database password secret key - if it is defined.
 */}}
 {{- define "keycloak.dbUserKey" -}}
-{{- if .Values.keycloak.persistence.existingSecret -}}
-  {{- required "missing existingSecretUsernameKey" .Values.keycloak.persistence.existingSecretUsernameKey -}}
+{{- if and .Values.keycloak.persistence.existingSecret .Values.keycloak.persistence.existingSecretUsernameKey -}}
+  {{- .Values.keycloak.persistence.existingSecretUsernameKey -}}
 {{- else -}}
   username
 {{- end -}}

--- a/charts/keycloak/templates/secret-db.yaml
+++ b/charts/keycloak/templates/secret-db.yaml
@@ -8,4 +8,7 @@ metadata:
 type: Opaque
 data:
   {{ include "keycloak.dbPasswordKey" . }}: {{ .Values.keycloak.persistence.dbPassword | b64enc | quote }}
+{{- if .Values.keycloak.persistence.existingSecretUsernameKey }}
+  {{ include "keycloak.dbUserKey" . }}: {{ .Values.keycloak.persistence.dbUser | b64enc | quote }}
+{{- end -}}
 {{- end -}}

--- a/charts/keycloak/templates/secret-db.yaml
+++ b/charts/keycloak/templates/secret-db.yaml
@@ -8,7 +8,5 @@ metadata:
 type: Opaque
 data:
   {{ include "keycloak.dbPasswordKey" . }}: {{ .Values.keycloak.persistence.dbPassword | b64enc | quote }}
-{{- if .Values.keycloak.persistence.existingSecretUsernameKey }}
   {{ include "keycloak.dbUserKey" . }}: {{ .Values.keycloak.persistence.dbUser | b64enc | quote }}
-{{- end -}}
 {{- end -}}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -284,24 +284,23 @@ keycloak:
     dbVendor: h2
 
     ## The following values only apply if "deployPostgres" is set to "false"
-
     dbName: keycloak
     dbHost: mykeycloak
     dbPort: 5432
 
+    ## Database Credentials are loaded from a Secret residing in the same Namespace as keycloak.
+    ## The Chart can read credentials from an existing Secret OR it can provision its own Secret.
 
-    # Database Credentials are loaded directly from values or from a
-    # Secret residing in the same Namespace as keycloak.
-    # Specifies an existing secret to be used for database credentials
+    ## Specify existing Secret
+    # If set, specifies the Name of an existing Secret to read db credentials from.
     existingSecret: ""
+    existingSecretPasswordKey: ""  # read keycloak db password from existingSecret under this Key
+    existingSecretUsernameKey: ""  # read keycloak db user from existingSecret under this Key
 
-    # The key in the existing secret that stores the password
-    existingSecretPasswordKey: ""  # read keycloak db password from Secret
-    existingSecretUsernameKey: ""  # read keycloak db user from Secret
-
-    # Only used if existingSecretUsernameKey is not specified.
-    dbUser: keycloak
+    ## Provision new Secret
     # Only used if existingSecret is not specified. In this case a new secret is created
+    # populated by the variables below.
+    dbUser: keycloak
     dbPassword: ""
 
 postgresql:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -279,18 +279,23 @@ keycloak:
 
     ## The following values only apply if "deployPostgres" is set to "false"
 
-    # Specifies an existing secret to be used for the database password
-    existingSecret: ""
-
-    # The key in the existing secret that stores the password
-    existingSecretKey: password
-
     dbName: keycloak
     dbHost: mykeycloak
     dbPort: 5432
-    dbUser: keycloak
 
-    # Only used if no existing secret is specified. In this case a new secret is created
+
+    # Database Credentials are loaded directly from values or from a
+    # Secret residing in the same Namespace as keycloak.
+    # Specifies an existing secret to be used for database credentials
+    existingSecret: ""
+
+    # The key in the existing secret that stores the password
+    existingSecretPasswordKey: ""  # read keycloak db password from Secret
+    existingSecretUsernameKey: ""  # read keycloak db user from Secret
+
+    # Only used if existingSecretUsernameKey is not specified.
+    dbUser: keycloak
+    # Only used if existingSecret is not specified. In this case a new secret is created
     dbPassword: ""
 
 postgresql:


### PR DESCRIPTION
Currently, only `DB_PASSWORD` can be loaded from a Secret, but not `DB_USER`.

We are using an operator pattern for db credential provisioning (think Hashicorp Vault) - and having a static username is not compatible with this pattern, since you are creating and deleting database roles as consuming pods go up and down.

This PR adds support for (optionally) reading the DB user from a secret.

The previous implementation used a variable named `keycloak.persistence.existingSecretKey` - which makes sense as long as you are only reading one value from the Secret. 

By adding another value to read from the Secret, this naming scheme is rendered unclear, so  `keycloak.persistence.existingSecretKey` becomes `keycloak.persistence.existingSecretPasswordKey` - which breaks backwards-compatibility, thus the **Major** version bump to `7.0.0`