### PR TITLE
Support db username from secret

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 6.0.2
+version: 6.0.3
 appVersion: 7.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -112,6 +112,8 @@ Parameter | Description | Default
 `keycloak.persistence.deployPostgres` | If true, the PostgreSQL chart is installed | `false`
 `keycloak.persistence.existingSecret` | Name of an existing secret to be used for the database password (if `keycloak.persistence.deployPostgres=false`). Otherwise a new secret is created | `""`
 `keycloak.persistence.existingSecretKey` | The key for the database password in the existing secret (if `keycloak.persistence.deployPostgres=false`) | `password`
+`keycloak.persistence.existingUserSecret` | Name of an existing secret to be used for the database username (if `keycloak.persistence.deployPostgres=false`). | `""`
+`keycloak.persistence.existingUserSecretKey` | The key for the database user in the existing secret (if `keycloak.persistence.deployPostgres=false`) | `user`
 `keycloak.persistence.dbVendor` | One of `h2`, `postgres`, `mysql`, or `mariadb` (if `deployPostgres=false`) | `h2`
 `keycloak.persistence.dbName` | The name of the database to connect to (if `deployPostgres=false`) | `keycloak`
 `keycloak.persistence.dbHost` | The database host name (if `deployPostgres=false`) | `mykeycloak`

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -165,7 +165,14 @@ Create environment variables for database configuration.
 - name: DB_DATABASE
   value: {{ .Values.keycloak.persistence.dbName | quote }}
 - name: DB_USER
+{{- if .Values.keycloak.persistence.existingUserSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.keycloak.persistence.existingUserSecret | quote }}
+      key: {{ .Values.keycloak.persistence.existingUserSecretKey | quote }}
+{{- else }}
   value: {{ .Values.keycloak.persistence.dbUser | quote }}
+{{- end }}
 - name: DB_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -285,6 +285,12 @@ keycloak:
 
     ## The following values only apply if "deployPostgres" is set to "false"
 
+    # Specifies an existing secret to be used for the database user
+    existingUserSecret: ""
+
+    # The key in the existing secret that stores the username
+    existingUserSecretKey: user
+
     # Specifies an existing secret to be used for the database password
     existingSecret: ""
 
@@ -294,6 +300,7 @@ keycloak:
     dbName: keycloak
     dbHost: mykeycloak
     dbPort: 5432
+    # Only used if no existing secret is specified.
     dbUser: keycloak
 
     # Only used if no existing secret is specified. In this case a new secret is created


### PR DESCRIPTION
I'm trying [MoveToKube's Postgres operator](https://operatorhub.io/operator/ext-postgres-operator) to manage database/roles creation. It creates a user with a somewhat dynamic name, but embeds it in a secret. Adding this functionality to the values for this chart allows me to use the operator outputs as-is!