### PR TITLE
[keycloak] Quote annotations

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 6.0.2
+version: 6.0.3
 appVersion: 7.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/ci/postgres-ha-values.yaml
+++ b/charts/keycloak/ci/postgres-ha-values.yaml
@@ -6,6 +6,7 @@ keycloak:
     test-label: test-label-value
   podAnnotations:
     test-annotation: "test-annotation-value-{{ .Release.Name }}"
+    test-int-annotation: "12345"
 
   startupScripts:
     hello.sh: |

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
         checksum/config-startup: {{ include (print .Template.BasePath "/configmap-startup.yaml") . | sha256sum }}
         {{- with .Values.keycloak.podAnnotations }}
         {{- range $key, $value := . }}
-        {{- printf "%s: %s" $key (tpl $value $) | nindent 8 }}
+        {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 8 }}
         {{- end }}
         {{- end }}
     spec:


### PR DESCRIPTION
Due to the fact that annotation values are templated
quoting got lost. This fixes the issue.

Signed-off-by: Reinhard Naegele <unguiculus@gmail.com>