### PR TITLE
Move ingress to networking.k8s api

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 6.0.3
+version: 6.0.4
 appVersion: 7.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $ingress := .Values.keycloak.ingress -}}
 {{- if $ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}


### PR DESCRIPTION
Accordingly to latest kubernetes docs https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource

Ingress right now moved outside of the extensions and right now it's part for the networking.k8s.io/v1beta1 api.