### PR TITLE
[keycloak] add support for loading prometheus monitoring at startup

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 6.1.0
+version: 6.1.1
 appVersion: 8.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -46,6 +46,10 @@ Parameter | Description | Default
 `init.image.pullPolicy` | Init image pull policy | `IfNotPresent`
 `init.resources` | Pod resource requests and limits for the init container | `{}`
 `clusterDomain` | The internal Kubernetes cluster domain | `cluster.local`
+`keycloak.prometheus.enabled` | Enables prometheus endpoint | `false`
+`keycloak.prometheus.image.repository` | The Prometheus init container image repository | `gottox/keycloak-metrics-spi-k8s`
+`keycloak.prometheus.image.tag` | The Prometheus init container  tag | `1.0.4`
+`keycloak.prometheus.image.pullPolicy` | The Keycloak image pull policy | `IfNotPresent`
 `keycloak.replicas` | The number of Keycloak replicas | `1`
 `keycloak.image.repository` | The Keycloak image repository | `jboss/keycloak`
 `keycloak.image.tag` | The Keycloak image tag | `8.0.1`

--- a/charts/keycloak/requirements.lock
+++ b/charts/keycloak/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 6.3.13
 digest: sha256:4bb0449bc5cb166117da05155a863a386fc6b04cea6428f2781d675711ea40a4
-generated: "2019-10-12T21:45:14.112985+02:00"
+generated: "2020-01-10T17:53:42.809622384+01:00"

--- a/charts/keycloak/templates/configmap-sh.yaml
+++ b/charts/keycloak/templates/configmap-sh.yaml
@@ -12,4 +12,9 @@ data:
     set -o errexit
     set -o nounset
 
+    if [ -d /plugins ]; then
+      mkdir -p /opt/jboss/keycloak/standalone/deployments
+      cp -au /plugins/* /opt/jboss/keycloak/standalone/deployments || :
+    fi
+
     exec /opt/jboss/tools/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ else }} -c standalone.xml{{ end }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -24,6 +24,12 @@ spec:
       annotations:
         checksum/config-sh: {{ include (print .Template.BasePath "/configmap-sh.yaml") . | sha256sum }}
         checksum/config-startup: {{ include (print .Template.BasePath "/configmap-startup.yaml") . | sha256sum }}
+        {{- if .Values.keycloak.prometheus.enabled }}
+        prometheus.io/path: /auth/realms/master/metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+        prometheus.io/scrape: "true"
+        {{- end }}
         {{- with .Values.keycloak.podAnnotations }}
         {{- range $key, $value := . }}
         {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 8 }}
@@ -47,8 +53,16 @@ spec:
         - name: {{ . }}
       {{- end }}
     {{- end }}
-    {{- if or .Values.keycloak.persistence.deployPostgres .Values.keycloak.extraInitContainers }}
+    {{- if or .Values.keycloak.persistence.deployPostgres .Values.keycloak.extraInitContainers .Values.keycloak.prometheus.enabled }}
       initContainers:
+      {{- if .Values.keycloak.prometheus.enabled }}
+        - name: keycloak-metrics-spi-k8s
+          image: "{{ .Values.keycloak.prometheus.image.repository }}:{{ .Values.keycloak.prometheus.image.tag }}"
+          imagePullPolicy: {{ .Values.init.image.pullPolicy }}
+          volumeMounts:
+          - name: keycloak-plugins
+            mountPath: /plugins
+      {{- end }}
       {{- if .Values.keycloak.persistence.deployPostgres }}
         - name: wait-for-postgresql
           image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
@@ -107,6 +121,8 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
+            - name: keycloak-plugins
+              mountPath: /plugins
             {{- if or .Values.keycloak.cli.enabled .Values.keycloak.startupScripts }}
             - name: startup
               mountPath: /opt/jboss/startup-scripts
@@ -160,6 +176,8 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 60
       volumes:
+        - name: keycloak-plugins
+          emptyDir: {}
         - name: sh
           configMap:
             name: {{ include "keycloak.fullname" . }}-sh

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -299,6 +299,12 @@ keycloak:
     # Only used if no existing secret is specified. In this case a new secret is created
     dbPassword: ""
 
+  prometheus:
+    enabled: false
+    image:
+      repository: gottox/keycloak-metrics-spi-k8s
+      tag: release-1.0.4
+      pullPolicy: IfNotPresent
 postgresql:
   ### PostgreSQL User to create.
   ##


### PR DESCRIPTION
This PR adds an option to load the [keycloak-metrics-spi](https://github.com/aerogear/keycloak-metrics-spi) plugin at startup. This adds support for prometheus monitoring with a simple config option.

ToDo:
* [x] add documentation
* [x] increas version in Chart.yaml