### PR TITLE
[keycloak] Allow templating for service annotation values

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 7.0.0
+version: 7.0.1
 appVersion: 8.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 6.2.0
+version: 6.2.1
 appVersion: 8.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -88,7 +88,7 @@ Parameter | Description | Default
 `keycloak.cli.logging` | WildFly CLI script for logging configuration | See `values.yaml`
 `keycloak.cli.ha` | Settings for HA setups | See `values.yaml`
 `keycloak.cli.custom` | Additional custom WildFly CLI script | `""`
-`keycloak.service.annotations` | Annotations for the Keycloak service | `{}`
+`keycloak.service.annotations` | Annotations for the Keycloak service. Values are passed through the `tpl` function | `{}`
 `keycloak.service.labels` | Additional labels for the Keycloak service | `{}`
 `keycloak.service.type` | The service type | `ClusterIP`
 `keycloak.service.httpPort` | The http service port | `80`

--- a/charts/keycloak/templates/service-http.yaml
+++ b/charts/keycloak/templates/service-http.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "keycloak.fullname" . }}-http
   {{- with $service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := . }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "keycloak.commonLabels" . | nindent 4 }}


### PR DESCRIPTION
 Keycloak service annotation update. Values are now passed through the `tpl` function.