### PR TITLE
[keycloak] Make pod management policy configurable

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 7.1.0
+version: 7.2.0
 appVersion: 8.0.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -74,6 +74,7 @@ Parameter | Description | Default
 `keycloak.podAnnotations` | Extra annotations to add to pod. Values are passed through the `tpl` function | `{}`
 `keycloak.hostAliases` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]`
 `keycloak.enableServiceLinks` | Indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links | `false`
+`keycloak.podManagementPolicy` | Pod management policy. One of `Parallel` or `OrderedReady` | `Parallel`
 `keycloak.restartPolicy` | Pod restart policy. One of `Always`, `OnFailure`, or `Never` | `Always`
 `keycloak.serviceAccount.create` | If `true`, a new service account is created | `false`
 `keycloak.serviceAccount.name` | Name of service account to use. If `serviceAccount.create=true`, a new service account is created with this name. | `"default" OR (if serviceAccount.create=true) keycloak.fullname`

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.keycloak.replicas }}
   serviceName: {{ include "keycloak.fullname" . }}-headless
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.keycloak.podManagementPolicy }}
   updateStrategy:
     type: RollingUpdate
   template:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -41,6 +41,8 @@ keycloak:
 
   enableServiceLinks: false
 
+  podManagementPolicy: Parallel
+
   restartPolicy: Always
 
   serviceAccount:


### PR DESCRIPTION
Adds a configurable `podManagementPolicy` value to the statefulset. The default value is set to `Parallel` to avoid breaking changes as a change to this value on an existing stateful set would fail.

When scaling up Keycloak by adding N+1 to the number of replicas, we see some nodes announce themselves with a UUID as indicated by this log:
```cli
20:35:03,941 INFO  [org.infinispan.CLUSTER] (MSC service thread 1-2) ISPN000094: Received new cluster view for channel ejb: [keycloak-0|3] (4) [keycloak-0, fd524605-7bc5-a6a4-ea6f-4604d418cb32, 35f6bdae-df5c-93e9-ead6-7f14873d346f, keycloak-1]
```

The new nodes will eventually be terminated and cluster will form without the UUID after there is N+1 restarts to the nodes. These are the logs that are output prior to restart:
```
20:40:59,531 WARN  [org.jgroups.protocols.TCP] (TQ-Bundler-7,ejb,keycloak-1) JGRP000032: keycloak-1: no physical address for 614634e4-ce11-2178-a44b-9bb20f21dfe4, dropping message
20:41:05,800 WARN  [org.jgroups.protocols.TCP] (TQ-Bundler-7,ejb,keycloak-1) JGRP000032: keycloak-1: no physical address for 614634e4-ce11-2178-a44b-9bb20f21dfe4, dropping message
20:41:09,421 ERROR [org.infinispan.interceptors.impl.InvocationContextInterceptor] (timeout-thread--p5-t1) ISPN000136: Error executing command PrepareCommand on Cache 'client-mappings', writing keys []: org.infinispan.util.concurrent.TimeoutException: ISPN000476: Timed out waiting for responses for request 9 from afcb2c50-4b3d-98d2-fe8b-374c7b449f4f
	at org.infinispan@9.4.16.Final//org.infinispan.remoting.transport.impl.MultiTargetRequest.onTimeout(MultiTargetRequest.java:167)
	at org.infinispan@9.4.16.Final//org.infinispan.remoting.transport.AbstractRequest.call(AbstractRequest.java:87)
	at org.infinispan@9.4.16.Final//org.infinispan.remoting.transport.AbstractRequest.call(AbstractRequest.java:22)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

Here is the total number of restarts required when scaling Keycloak from 1 to 4 (on production, this is something we would prefer to avoid as we have various extensions that extend the bootup time):
```cli
NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          12m
keycloak-1   1/1     Running   2          10m
keycloak-2   1/1     Running   3          10m
keycloak-3   1/1     Running   1          10m
```

As a workaround, we would have to scale Keycloak one node at a time or if we set the management policy to `OrderedReady`. 