### PR TITLE
[keycloak] Update to 9.0.0 and add additional configuration

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: keycloak
-version: 7.2.0
-appVersion: 8.0.1
+version: 7.3.0
+appVersion: 9.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -48,7 +48,7 @@ Parameter | Description | Default
 `clusterDomain` | The internal Kubernetes cluster domain | `cluster.local`
 `keycloak.replicas` | The number of Keycloak replicas | `1`
 `keycloak.image.repository` | The Keycloak image repository | `jboss/keycloak`
-`keycloak.image.tag` | The Keycloak image tag | `8.0.1`
+`keycloak.image.tag` | The Keycloak image tag | `9.0.0`
 `keycloak.image.pullPolicy` | The Keycloak image pull policy | `IfNotPresent`
 `keycloak.image.pullSecrets` | Image pull secrets | `[]`
 `keycloak.basepath` | Path keycloak is hosted at | `auth`
@@ -58,9 +58,10 @@ Parameter | Description | Default
 `keycloak.existingSecretKey` |  The key in `keycloak.existingSecret` that stores the admin password | `password`
 `keycloak.jgroups.discoveryProtocol` | The protocol for JGroups discovery | `dns.DNS_PING`
 `keycloak.jgroups.discoveryProperties` | Properties for JGroups discovery. Passed through the `tpl` function | `"dns_query={{ template "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"`
+`keycloak.javaToolOptions` | Java tool options | `"-XX:+UseContainerSupport -XX:MaxRAMPercentage=50"`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraContainers` | Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy. Passed through the `tpl` function and thus to be configured a string | `""`
-`keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. You probably want to set `PROXY_ADDRESS_FORWARDING="true"` if your instance is running behind a reverse proxy. Passed through the `tpl` function and thus to be configured a string. | `""`
+`keycloak.extraEnv` | Allows the specification of additional environment variables for Keycloak. Passed through the `tpl` function and thus to be configured a string. | `""`
 `keycloak.extraVolumeMounts` | Add additional volumes mounts, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraVolumes` | Add additional volumes, e. g. for custom themes. Passed through the `tpl` function and thus to be configured a string | `""`
 `keycloak.extraPorts` | Add additional ports, e. g. for custom admin console port. Passed through the `tpl` function and thus to be configured a string | `""`
@@ -74,6 +75,7 @@ Parameter | Description | Default
 `keycloak.podAnnotations` | Extra annotations to add to pod. Values are passed through the `tpl` function | `{}`
 `keycloak.hostAliases` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]`
 `keycloak.enableServiceLinks` | Indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links | `false`
+`keycloak.proxyAddressForwarding` | Enables proxy address forwarding if your instance is running behind a reverse proxy | `true`
 `keycloak.podManagementPolicy` | Pod management policy. One of `Parallel` or `OrderedReady` | `Parallel`
 `keycloak.restartPolicy` | Pod restart policy. One of `Always`, `OnFailure`, or `Never` | `Always`
 `keycloak.serviceAccount.create` | If `true`, a new service account is created | `false`
@@ -82,6 +84,7 @@ Parameter | Description | Default
 `keycloak.containerSecurityContext` | Security context for containers running in the pod. Will not be inherited by additionally injected containers | `{runAsUser: 1000, runAsNonRoot: true}`
 `keycloak.startupScripts` | Custom startup scripts to run before Keycloak starts up | `[]`
 `keycloak.lifecycleHooks` | Container lifecycle hooks. Passed through the `tpl` function and thus to be configured a string | ``
+`keycloak.terminationGracePeriodSeconds` | Termination grace period in seconds for Keycloak shutdown. Clusters with a large cache might need to extend this to give Infinispan more time to rebalance | `60`
 `keycloak.extraArgs` | Additional arguments to the start command | ``
 `keycloak.livenessProbe` | Liveness probe configuration. Passed through the `tpl` function and thus to be configured as string | See `values.yaml`
 `keycloak.readinessProbe` | Readiness probe configuration. Passed through the `tpl` function and thus to be configured as string | See `values.yaml`
@@ -457,19 +460,18 @@ This allows for greater customizability of the readiness and liveness probes.
 The defaults are unchanged, but since 6.0.0 configured as follows:
 
 ```yaml
-livenessProbe: |
-  httpGet:
-    path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
-    port: http
-  initialDelaySeconds: 120
-  timeoutSeconds: 5
-
-readinessProbe: |
-  httpGet:
-    path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
-    port: http
-  initialDelaySeconds: 30
-  timeoutSeconds: 1
+  livenessProbe: |
+    httpGet:
+      path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/
+      port: http
+    initialDelaySeconds: 300
+    timeoutSeconds: 5
+  readinessProbe: |
+    httpGet:
+      path: {{ if ne .Values.keycloak.basepath "" }}/{{ .Values.keycloak.basepath }}{{ end }}/realms/master
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 1
 ```
 
 #### Changes in Existing Secret Configuration

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -88,6 +88,12 @@ spec:
               value: {{ .Values.keycloak.username }}
             - name: KEYCLOAK_PASSWORD_FILE
               value: /secrets/{{ include "keycloak.passwordKey" . }}
+            - name: JAVA_TOOL_OPTIONS
+              value: {{ .Values.keycloak.javaToolOptions | quote }}
+          {{- if .Values.keycloak.proxyAddressForwarding }}
+            - name: PROXY_ADDRESS_FORWARDING
+              value: "true"
+          {{- end }}
           {{- if $highAvailability }}
             - name: JGROUPS_DISCOVERY_PROTOCOL
               value: {{ .Values.keycloak.jgroups.discoveryProtocol }}
@@ -158,7 +164,7 @@ spec:
       {{- with .Values.keycloak.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.keycloak.terminationGracePeriodSeconds }}
       volumes:
         - name: sh
           configMap:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -24,7 +24,7 @@ keycloak:
 
   image:
     repository: jboss/keycloak
-    tag: 8.0.1
+    tag: 9.0.0
     pullPolicy: IfNotPresent
 
     ## Optionally specify an array of imagePullSecrets.
@@ -38,6 +38,8 @@ keycloak:
   #  - ip: "1.2.3.4"
   #    hostnames:
   #      - "my.host.com"
+
+  proxyAddressForwarding: true
 
   enableServiceLinks: false
 
@@ -74,6 +76,9 @@ keycloak:
     #   exec:
     #     command: ["/bin/sh", "-c", "ls"]
 
+  ## Override the default for the Keycloak container, e.g. for clusters with large cache that requires rebalancing.
+  terminationGracePeriodSeconds: 60
+
   ## Additional arguments to start command e.g. -Dkeycloak.import= to load a realm
   extraArgs: ""
 
@@ -96,10 +101,10 @@ keycloak:
     discoveryProperties: >
       "dns_query={{ template "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
 
+  javaToolOptions: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=50"
+
   ## Allows the specification of additional environment variables for Keycloak
   extraEnv: |
-    - name: PROXY_ADDRESS_FORWARDING
-      value: "true"
     # - name: KEYCLOAK_LOGLEVEL
     #   value: DEBUG
     # - name: WILDFLY_LOGLEVEL


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

* update keycloak image to 9.0.0
* introduced proxyAddressForwarding variable (removes it from extraEnv as using additional extraenv requires you to add the variable again to your list or its not merged)
* introduced javaToolOptions variable (defaults to "-XX:+UseContainerSupport -XX:MaxRAMPercentage=50" instead of using static memory config)
* fixed values of readiness & liveness probes in the readme

fixes: https://github.com/codecentric/helm-charts/issues/181