### PR TITLE
[jenkins] Add environment variables to the init container and set revisonHistoryLimit

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jenkins
 description: The leading open source automation server
-version: 1.5.1
+version: 1.6.0
 appVersion: 2.190.1
 home: https://jenkins.io/
 icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png

--- a/charts/jenkins/templates/deployment.yaml
+++ b/charts/jenkins/templates/deployment.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       {{- include "jenkins.selectorLabels" . | nindent 6 }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy:
     type: Recreate
   template:

--- a/charts/jenkins/templates/deployment.yaml
+++ b/charts/jenkins/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         - name: jenkins-init
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
           command:
             - /init/init.sh
           args:


### PR DESCRIPTION
Hi there,

we are running a kubernetes cluster behind a proxy and then the init container can't pull plugins after the deployment. To enable the init container to pull stuff from outside i reuse the extraEnv vars for the init container too. 

The second patch sets the revisionHistory limit for the deployment. Sometimes we have the need to configure more or less than the default of 10 old sets.

Regards
Sascha