### PR TITLE
Make SMTP service name istio-friendly

### DIFF
--- a/charts/mailhog/templates/service.yaml
+++ b/charts/mailhog/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort.http))) }}
       nodePort: {{ .Values.service.nodePort.http }}
       {{- end }}
-    - name: smtp
+    - name: tcp-smtp
       port: {{ .Values.service.port.smtp }}
       protocol: TCP
       targetPort: smtp


### PR DESCRIPTION
Hey guys,

Just a small amendment to mailhog's service's port name for SMTP, so that Istio mTLS can correctly identify the traffic as TCP, and not HTTP (the default)

Cheers!
D