### PR TITLE
[mailhog] Use networking.k8s.io/v1beta1 API for Ingress

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: 1.0.0
-version: 3.1.2
+version: 3.1.3
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mailhog.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
This PR switches `mailhog`'s Ingress `apiVersion` to `networking.k8s.io/v1beta1`

## Motivation

In [1.18 Kubernetes `extensions/v1beta1` for Ingress is disabled completely](https://github.com/kubernetes/kubernetes/blob/0f1a27bceeca8f1d37cd69f33d642e38ab414192/CHANGELOG/CHANGELOG-1.18.md#kube-apiserver-1).
