### PR TITLE
[keycloak] Add support for adding annotations to the StatefulSet

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 7.5.0
+version: 7.6.0
 appVersion: 9.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -73,6 +73,7 @@ Parameter | Description | Default
 `keycloak.tolerations` | Node taints to tolerate | `[]`
 `keycloak.podLabels` | Extra labels to add to pod | `{}`
 `keycloak.podAnnotations` | Extra annotations to add to pod. Values are passed through the `tpl` function | `{}`
+`keycloak.statefulsetAnnotations` | Extra annotations to add to statefulset. Values are passed through the `tpl` function | `{}`
 `keycloak.hostAliases` | Mapping between IP and hostnames that will be injected as entries in the pod's hosts files | `[]`
 `keycloak.enableServiceLinks` | Indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links | `false`
 `keycloak.proxyAddressForwarding` | Enables proxy address forwarding if your instance is running behind a reverse proxy | `true`

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -3,6 +3,14 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "keycloak.fullname" . }}
+  {{- if .Values.keycloak.statefulsetAnnotations }}
+  annotations:
+    {{- with .Values.keycloak.statefulsetAnnotations }}
+    {{- range $key, $value := . }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
   labels:
     {{- include "keycloak.commonLabels" . | nindent 4 }}
 spec:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -214,6 +214,9 @@ keycloak:
     # maxUnavailable: 1
     # minAvailable: 1
 
+  ## Extra annotations to be added to statefulset
+  statefulsetAnnotations: {}
+
   service:
     annotations: {}
     # service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"


### PR DESCRIPTION
We make use of custom annotations for our release process automation; this adds support for annotations to the statefulset 

Signed-off-by: Diego Rodriguez <drodriguez@opengov.com>