### PR TITLE
Release name in deployment labels

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: 1.0.0
-version: 3.1.3
+version: 3.1.4
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/chart: {{ include "mailhog.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
@@ -21,6 +22,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "mailhog.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        release: {{ .Release.Name }}
     spec:
       {{- with .Values.securityContext }}
       securityContext:


### PR DESCRIPTION
Most helm charts add `.Release.Name` to deployment labels, which makes it easier to select the resource.