### PR TITLE
helm install v2 to v3

### DIFF
--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -7,7 +7,7 @@ The leading open source automation server
 ## TL;DR;
 
 ```console
-$ helm install codecentric/jenkins
+$ helm install codecentric/jenkins --generate-name
 ```
 
 ## Introduction
@@ -53,7 +53,7 @@ Minimum required Kubernetes version is 1.9.
 To install the chart with the release name `jenkins`:
 
 ```console
-$ helm install --name jenkins codecentric/jenkins
+$ helm install jenkins codecentric/jenkins
 ```
 
 ## Uninstalling the Chart
@@ -131,7 +131,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 For example,
 
 ```bash
-$ helm install --name jenkins -f values.yaml stable/jenkins
+$ helm install jenkins -f values.yaml stable/jenkins
 ```
 
 With the chart's default configuration, an initial admin user is automatically created and you will be guided through the installation wizard.

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install codecentric/keycloak
+$ helm install codecentric/keycloak --generate-name
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ By default, the PostgreSQL chart requires PV support on underlying infrastructur
 To install the chart with the release name `keycloak`:
 
 ```console
-$ helm install --name keycloak codecentric/keycloak
+$ helm install keycloak codecentric/keycloak
 ```
 
 ## Uninstalling the Chart
@@ -151,7 +151,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name keycloak -f values.yaml codecentric/keycloak
+$ helm install keycloak -f values.yaml codecentric/keycloak
 ```
 
 ### Usage of the `tpl` Function

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```bash
-$ helm install stable/mailhog
+$ helm install stable/mailhog --generate-name
 ```
 
 ## Introduction
@@ -22,7 +22,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release codecentric/mailhog
+$ helm install my-release codecentric/mailhog
 ```
 
 The command deploys Mailhog on the Kubernetes cluster in the default configuration. The [configuration](#configuration)
@@ -74,7 +74,7 @@ Parameter | Description | Default
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-$ helm install --name my-release \
+$ helm install my-release \
   --set env.MH_UI_WEB_PATH=mailhog \
     stable/mailhog
 ```
@@ -82,5 +82,5 @@ $ helm install --name my-release \
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/mailhog
+$ helm install my-release -f values.yaml stable/mailhog
 ```


### PR DESCRIPTION
`helm install` in the docs are not working with helm v3, because now it is `hem install xx` instead of `helm install --name xx`

error : "Error: unknown flag: --name"

#223

https://helm.sh/docs/topics/v2_v3_migration/

There are other deprecations but my understanding of helm is limited so I couldn't create a complete PR "helm v2 to v3", it is just about `helm install` , feel free to cancel this PR if you prefer a complete v2 to v3 PR

Signed-off-by: nicolasmlv <nicolas.maloeuvre@gmail.com>