### PR TITLE
Fix typo on mailhog chart

### DIFF
--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```bash
-$ helm install stable/mailhog
+$ helm install codecentric/mailhog
 ```
 
 ## Introduction
@@ -77,11 +77,11 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install --name my-release \
   --set env.MH_UI_WEB_PATH=mailhog \
-    stable/mailhog
+    codecentric/mailhog
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/mailhog
+$ helm install --name my-release -f values.yaml codecentric/mailhog
 ```


### PR DESCRIPTION
This PR simply fixes the typo on README instructions related to mailhog chart.