### PR TITLE
[keycloak] Add `tpl` to Keycloak DB Config

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 8.2.2
+version: 8.2.3
 appVersion: 10.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -173,11 +173,11 @@ Create environment variables for database configuration.
   value: {{ .Values.keycloak.persistence.dbVendor | quote }}
 {{- if not (eq "h2" .Values.keycloak.persistence.dbVendor) }}
 - name: DB_ADDR
-  value: {{ .Values.keycloak.persistence.dbHost | quote }}
+  value: {{ tpl .Values.keycloak.persistence.dbHost . | quote }}
 - name: DB_PORT
   value: {{ .Values.keycloak.persistence.dbPort | quote }}
 - name: DB_DATABASE
-  value: {{ .Values.keycloak.persistence.dbName | quote }}
+  value: {{ tpl .Values.keycloak.persistence.dbName . | quote }}
 - name: DB_USER
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
Add `tpl` to `keycloak.persistence.dbName|dbHost`
The reason for this is so that you can, for example, use utils to generate the DB Name and Host

For example:
```yaml
# values.yaml
global:
  postgres:
    host: my-example-aurora.cluster-0zZBHhzWt0rI.us-east-1.rds.amazonaws.com

keycloak:
  persistence:
    dbName: keycloak_{{ .Release.Namespace }}
    dbHost: {{ .Values.global.postgres.host }}
```