### PR TITLE
Fix missmatch between README and _helper.tpl

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 8.2.2
+version: 8.2.3
 appVersion: 10.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -178,11 +178,16 @@ Create environment variables for database configuration.
   value: {{ .Values.keycloak.persistence.dbPort | quote }}
 - name: DB_DATABASE
   value: {{ .Values.keycloak.persistence.dbName | quote }}
+{{- if .Values.keycloak.persistence.existingSecretUsernameKey }}
 - name: DB_USER
   valueFrom:
     secretKeyRef:
       name: {{ include "keycloak.dbSecretName" . }}
       key: {{ include "keycloak.dbUserKey" . | quote }}
+{{- else }}
+- name: DB_USER
+  value: {{ .Values.keycloak.persistence.dbUser | quote }}
+{{- end }}
 - name: DB_PASSWORD
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
in the README the param keycloak.persistence.existingSecretUsernameKey is
supposed to default to the value of .keycloak.persistence.dbUser if it is
left unset.

Fixes #191

Signed-off-by: Steve Foster <stephen.foster@taitradio.com>