### PR TITLE
[keycloak] Revert liveness probe

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.0.0
+version: 9.0.1
 appVersion: 11.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -153,8 +153,8 @@ podAnnotations: {}
 # Liveness probe configuration
 livenessProbe: |
   httpGet:
-    path: /health/live
-    port: http-management
+    path: /auth/
+    port: http
   initialDelaySeconds: 300
   timeoutSeconds: 5
 


### PR DESCRIPTION
This reverts the changed liveness probe back to the previous
one because the management port by default binds to 127.0.0.1
and, thus, is not available. This is something a user should
actively reconfigure. Also, using WildFly health endpoints
didn't really add any value.

Fixes: #266
Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>