### PR TITLE
Feat. Ability to pass arguments to startup command

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: 1.0.0
-version: 3.2.0
+version: 3.2.1
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -71,6 +71,7 @@ Parameter | Description | Default
 `ingress.hosts` | A list of ingress hosts | `{ host: mailhog.example.com, paths: ["/"] }`
 `ingress.tls` | A list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
 `extraEnv` | Additional environment variables, see [CONFIG.md](https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md) | `{}`
+`startup.args` | Additional arguments to be passed to startup command (Mailhog). Eg. Skip writing logs to stdout by passing `&>/dev/null` as arg | `[]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
         - name: {{ template "mailhog.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          args:
+          - MailHog {{ join " " .Values.startup.args }}
           env:
             - name: MH_HOSTNAME
               valueFrom:

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -3,6 +3,9 @@ image:
   tag: v1.0.0
   pullPolicy: IfNotPresent
 
+startup:
+  args: []
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Ability to pass in arguments to startup command for Mailhog

#### Which issue this PR fixes
  - fixes https://github.com/mailhog/MailHog/issues/56

#### Example Use-case

To suppress logs emitted by Mailhog, you can pass `&>/dev/null` as helm value using `startup.args`