### PR TITLE
[keycloak] fix object type of extraEnv in schema

### DIFF
--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -56,7 +56,14 @@
       "type": "string"
     },
     "extraEnv": {
-      "type": "string"
+      "type": "array",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
     },
     "extraEnvFrom": {
       "type": "string"


### PR DESCRIPTION
Keycloaks `values.yaml.schema` incorrectly forced `extraEnv` to be a string, which is kind of silly, as it needs to be an array containing `.name` and `.value` items.

Technically fixes codecentric/helm-charts#271