### PR TITLE
[keycloak] Do not set enableServiceLinks when false

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.3.0
+version: 9.3.1
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -151,7 +151,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.enableServiceLinks }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
The specification of `enableServiceLinks` gives an error on older Kubernetes versions.
`enableServiceLinks` is now only specified when its value is false