### PR TITLE
[keycloak] Update ingress API version

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.4.0
+version: 9.6.0
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -87,3 +87,15 @@ Create the namespace for the ServiceMonitor deployment
 {{ .Release.Namespace }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if semverCompare ">=1.19.0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -92,8 +92,8 @@ Create the namespace for the ServiceMonitor deployment
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
-{{- define "ingress.apiVersion" -}}
-{{- if semverCompare ">=1.19.0" .Capabilities.KubeVersion.GitVersion -}}
+{{- define "keycloak.ingressAPIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+apiVersion: {{ include "keycloak.ingressAPIVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}


### PR DESCRIPTION
Update ingress version to work with kubernetes 1.19

uses a helper function to select v1 or v1beta1