### PR TITLE
[keycloak] Add the global.imageRegistry option

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.4.0
+version: 10.0.0
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -41,11 +41,13 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 | Parameter | Description | Default |
 |---|---|---|
+| `global.imageRegistry` | Global Docker Image registry | `nil`
 | `fullnameOverride` | Optionally override the fully qualified name | `""` |
 | `nameOverride` | Optionally override the name | `""` |
 | `replicas` | The number of replicas to create | `1` |
-| `image.repository` | The Keycloak image repository | `docker.io/jboss/keycloak` |
-| `image.tag` | Overrides the Keycloak image tag whose default is the chart version | `""` |
+| `image.registry` | The Keycloak image registry | `docker.io` |
+| `image.repository` | The Keycloak image repository | `jboss/keycloak` |
+| `image.tag` | The Keycloak image tag | `11.0.2` |
 | `image.pullPolicy` | The Keycloak image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Image pull secrets for the Pod | `[]` |
 | `hostAliases` | Mapping between IPs and hostnames that will be injected as entries in the Pod's hosts files | `[]` |
@@ -118,7 +120,8 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `route.tls.enabled` | If `true`, TLS is enabled for the Route | `true` |
 | `route.tls.insecureEdgeTerminationPolicy` | Insecure edge termination policy of the Route. Can be `None`, `Redirect`, or `Allow` | `Redirect` |
 | `route.tls.termination` | TLS termination of the route. Can be `edge`, `passthrough`, or `reencrypt` | `edge` |
-| `pgchecker.image.repository` | Docker image used to check Postgresql readiness at startup | `docker.io/busybox` |
+| `pgchecker.image.registry` | Docker image registry used to check Postgresql readiness at startup | `docker.io` |
+| `pgchecker.image.repository` | Docker image used to check Postgresql readiness at startup | `busybox` |
 | `pgchecker.image.tag` | Image tag for the pgchecker image | `1.32` |
 | `pgchecker.image.pullPolicy` | Image pull policy for the pgchecker image | `IfNotPresent` |
 | `pgchecker.securityContext` | SecurityContext for the pgchecker container | `{"allowPrivilegeEscalation":false,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` |
@@ -563,6 +566,11 @@ Additionally, we get stable values for `jboss.node.name` which can be advantageo
 The headless service that governs the StatefulSet is used for DNS discovery via DNS_PING.
 
 ## Upgrading
+
+### From chart versions < 10.0.0
+
+The `image.registry`, `pgchecker.image.registry` and `global.imageRegistry` properties were added.
+That means `image.repository` and `pgchecker.image.registry` don't include the registry anymore.
 
 ### From chart versions < 9.0.0
 

--- a/charts/keycloak/requirements.lock
+++ b/charts/keycloak/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.1
-digest: sha256:33ee9e6caa9e519633071fd71aedd9de7906b9a9d7fb629eb814d9f72bb8d68e
-generated: "2020-07-24T07:40:55.78753+02:00"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.x.x
+digest: sha256:0d7f59ddc3b832bc60db7fe6acc20b51d3fbb83084d4f69eb32ca474800a435f
+generated: "2020-10-19T14:01:26.8811468+03:00"

--- a/charts/keycloak/requirements.lock
+++ b/charts/keycloak/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.1.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 0.x.x
-digest: sha256:0d7f59ddc3b832bc60db7fe6acc20b51d3fbb83084d4f69eb32ca474800a435f
-generated: "2020-10-19T14:01:26.8811468+03:00"
+  version: 0.8.2
+digest: sha256:ed3ffbcf4dd5866ec1e8374f0e1150f0a0a23cdde24bf8d06454eec47fcb258f
+generated: "2020-10-19T15:04:49.6121664+03:00"

--- a/charts/keycloak/requirements.yaml
+++ b/charts/keycloak/requirements.yaml
@@ -3,3 +3,6 @@ dependencies:
     version: 9.1.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
+  - name: common
+    version: 0.x.x
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/keycloak/requirements.yaml
+++ b/charts/keycloak/requirements.yaml
@@ -4,5 +4,5 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: common
-    version: 0.x.x
+    version: 0.8.2
     repository: https://charts.bitnami.com/bitnami

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -32,6 +32,20 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Return the proper Keycloak image name
+*/}}
+{{- define "keycloak.image" -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global ) -}}
+{{- end -}}
+
+{{/*
+Return the proper pgchecker image name
+*/}}
+{{- define "pgchecker.image" -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.pgchecker.image "global" .Values.global ) -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "keycloak.labels" -}}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
       initContainers:
         {{- if .Values.postgresql.enabled }}
         - name: pgchecker
-          image: "{{ .Values.pgchecker.image.repository }}:{{ .Values.pgchecker.image.tag }}"
+          image: {{ template "pgchecker.image" . }}
           imagePullPolicy: {{ .Values.pgchecker.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.pgchecker.securityContext | nindent 12 }}
@@ -69,7 +69,7 @@ spec:
         - name: keycloak
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ template "keycloak.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             {{- toYaml .Values.command | nindent 12 }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -16,6 +16,9 @@
           "type": "string",
           "pattern": "^(Always|Never|IfNotPresent)$"
         },
+        "registry": {
+          "type": "string"
+        },
         "repository": {
           "type": "string"
         },

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -8,10 +8,12 @@ nameOverride: ""
 replicas: 1
 
 image:
+  # The Keycloak image registry
+  registry: docker.io
   # The Keycloak image repository
-  repository: docker.io/jboss/keycloak
-  # Overrides the Keycloak image tag whose default is the chart version
-  tag: ""
+  repository: jboss/keycloak
+  # The Keycloak image tag
+  tag: 11.0.2
   # The Keycloak image pull policy
   pullPolicy: IfNotPresent
 
@@ -299,8 +301,10 @@ route:
 
 pgchecker:
   image:
+    # Docker image registry used to check Postgresql readiness at startup
+    registry: docker.io
     # Docker image used to check Postgresql readiness at startup
-    repository: docker.io/busybox
+    repository: busybox
     # Image tag for the pgchecker image
     tag: 1.32
     # Image pull policy for the pgchecker image


### PR DESCRIPTION
This change allows one to specify the image registry which will be used for each image individually, as well as a global image registry to override all image registries.

I used Bitnami's common chart to keep things standard and generic.

This change is extremely beneficial to those who use an airgapped environment with a private image registry.