### PR TITLE
[keycloak] Add autoscaling support and KUBE_PING documentation

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.4.0
+version: 9.5.0
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -149,7 +149,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `prometheusRule.annotations` | Annotations for the PrometheusRule | `{}` |
 | `prometheusRule.labels` | Additional labels for the PrometheusRule | `{}` |
 | `prometheusRule.rules` | List of rules for Prometheus | `[]` |
-| `autoscaling.enabled.true` | Enable creation of a HorizontalPodAutoscaler resource | `false` |
+| `autoscaling.enabled` | Enable creation of a HorizontalPodAutoscaler resource | `false` |
 | `autoscaling.labels` | Additional labels for the HorizontalPodAutoscaler resource | `{}` |
 | `autoscaling.minReplicas` | The minimum number of Pods when autoscaling is enabled | `3` |
 | `autoscaling.maxReplicas` | The maximum number of Pods when autoscaling is enabled | `10` |

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -149,7 +149,8 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `prometheusRule.annotations` | Annotations for the PrometheusRule | `{}` |
 | `prometheusRule.labels` | Additional labels for the PrometheusRule | `{}` |
 | `prometheusRule.rules` | List of rules for Prometheus | `[]` |
-| `autoscaling.create.true` | Enable creation of a HorizontalPodAutoscaler resource | `false` |
+| `autoscaling.enabled.true` | Enable creation of a HorizontalPodAutoscaler resource | `false` |
+| `autoscaling.labels` | Additional labels for the HorizontalPodAutoscaler resource | `{}` |
 | `autoscaling.minReplicas` | The minimum number of Pods when autoscaling is enabled | `3` |
 | `autoscaling.maxReplicas` | The maximum number of Pods when autoscaling is enabled | `10` |
 | `autoscaling.metrics` | The metrics configuration for the HorizontalPodAutoscaler | `[{"resource":{"name":"cpu","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` |
@@ -331,7 +332,8 @@ extraEnv: |
 
 #### KUBE_PING Service Discovery
 
-Recent versions of Keycloak include a new Kuberntes Native [KUBE_PING](https://github.com/jgroups-extras/jgroups-kubernetes) service discovery protocol. This requires a little more configuration than DNS_PING but it is not difficult through the Helm Chart.
+Recent versions of Keycloak include a new Kubernetes native [KUBE_PING](https://github.com/jgroups-extras/jgroups-kubernetes) service discovery protocol.
+This requires a little more configuration than DNS_PING but can easily be achieved with the Helm chart.
 
 As with DNS_PING some environment variables must be configured as follows:
 
@@ -350,13 +352,12 @@ extraEnv: |
     value: "2"
 ```
 
-However the Keycloak Pods must also be able to `get` and `list` Pods in the namespace which can be configured as follows:
+However, the Keycloak Pods must also get RBAC permissions to `get` and `list` Pods in the namespace which can be configured as follows:
 
 ```yaml
 rbac:
   create: true
   rules:
-  RBAC rules for KUBE_PING
     - apiGroups:
         - ""
       resources:
@@ -368,15 +369,16 @@ rbac:
 
 #### Autoscaling
 
-Due to the caches in Keycloak only replicating to a few nodes (2 in the example configuration above) and the limited controls around autoscaling built into Kubernetes it has historically been problematic to autoscale Keycloak. However in Kubernetes 1.18 [additional controls were introduced](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior) which make it possible to scale down in a more controlled manner.
+Due to the caches in Keycloak only replicating to a few nodes (two in the example configuration above) and the limited controls around autoscaling built into Kubernetes, it has historically been problematic to autoscale Keycloak.
+However, in Kubernetes 1.18 [additional controls were introduced](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior) which make it possible to scale down in a more controlled manner.
 
-The example autoscaling configuration in the values file scales from 3 up to a maximum of 10 Pods using CPU utilization as the metric. Scaling up is done as quickly as required but scaling down is done at a maximum rate of one Pod per 5 minutes.
+The example autoscaling configuration in the values file scales from three up to a maximum of ten Pods using CPU utilization as the metric. Scaling up is done as quickly as required but scaling down is done at a maximum rate of one Pod per five minutes.
 
 Autoscaling can be enabled as follows:
 
 ```yaml
 autoscaling:
-  create: true
+  enabled: true
 ```
 
 KUBE_PING service discovery seems to be the most reliable mechanism to use when enabling autoscaling, due to being faster than DNS_PING at detecting changes in the cluster.
@@ -746,4 +748,3 @@ kubectl label pod -n "$namespace" -l app=keycloak -l release="$release" app.kube
 **NOTE:** Version 5.0.0 also updates the Postgresql dependency which has received a major upgrade as well.
 In case you use this dependency, the database must be upgraded first.
 Please refer to the Postgresql chart's upgrading section in its README for instructions.
-

--- a/charts/keycloak/templates/hpa.yaml
+++ b/charts/keycloak/templates/hpa.yaml
@@ -1,8 +1,13 @@
-{{- if .Values.autoscaling.create }}
+{{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.autoscaling.labels }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/keycloak/templates/hpa.yaml
+++ b/charts/keycloak/templates/hpa.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.autoscaling.create }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "keycloak.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics: 
+    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+{{- end }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -17,7 +17,9 @@ spec:
   selector:
     matchLabels:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}
+  {{- if not .Values.autoscaling.create }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   serviceName: {{ include "keycloak.fullname" . }}-headless
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     matchLabels:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}
-  {{- if not .Values.autoscaling.create }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   serviceName: {{ include "keycloak.fullname" . }}-headless

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -380,8 +380,11 @@
       "autoscaling": {
         "type": "object",
         "properties": {
-          "create": {
+          "enabled": {
             "type": "boolean"
+          },
+          "labels": {
+            "type": "object"
           },
           "minReplicas": {
             "type": "integer"

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -377,6 +377,26 @@
       "terminationGracePeriodSeconds": {
         "type": "integer"
       },
+      "autoscaling": {
+        "type": "object",
+        "properties": {
+          "create": {
+            "type": "boolean"
+          },
+          "minReplicas": {
+            "type": "integer"
+          },
+          "maxReplicas": {
+            "type": "integer"
+          },
+          "metrics": {
+            "type": "array"
+          },
+          "behavior": {
+            "type": "object"
+          }
+        }
+      },
       "test": {
         "type": "object",
         "properties": {

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 # Optionally override the name
 nameOverride: ""
 
-# The number of replicas to create
+# The number of replicas to create (has no effect if autoscaling enabled)
 replicas: 1
 
 image:
@@ -404,6 +404,32 @@ prometheusRule:
   #   for: 5m
   #   labels:
   #     severity: warning
+
+autoscaling:
+  # If `true`, a autoscaling/v2beta2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)
+  # Autoscaling seems to be most reliable when using KUBE_PING service discovery (see README for details)
+  # This disables the `replicas` field in the StatefulSet
+  create: false
+  # The minimum and maximum number of replicas for the Keycloak StatefulSet
+  minReplicas: 3
+  maxReplicas: 10
+  # The metrics to use for scaling
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+  # The scaling policy to use. This will scale up quickly but only scale down a single Pod per 5 minutes.
+  # This is important because caches are usually only replicated to 2 Pods and if one of those Pods is terminated this will give the cluster time to recover.
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 300
 
 test:
   # If `true`, test resources are created

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -409,27 +409,29 @@ autoscaling:
   # If `true`, a autoscaling/v2beta2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)
   # Autoscaling seems to be most reliable when using KUBE_PING service discovery (see README for details)
   # This disables the `replicas` field in the StatefulSet
-  create: false
+  enabled: false
+  # Additional HorizontalPodAutoscaler labels
+  labels: {}
   # The minimum and maximum number of replicas for the Keycloak StatefulSet
   minReplicas: 3
   maxReplicas: 10
   # The metrics to use for scaling
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 80
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
   # The scaling policy to use. This will scale up quickly but only scale down a single Pod per 5 minutes.
   # This is important because caches are usually only replicated to 2 Pods and if one of those Pods is terminated this will give the cluster time to recover.
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 300
       policies:
-      - type: Pods
-        value: 1
-        periodSeconds: 300
+        - type: Pods
+          value: 1
+          periodSeconds: 300
 
 test:
   # If `true`, test resources are created


### PR DESCRIPTION
We've been implementing autoscaling for our Keycloak environment as well as switching to KUBE_PING after having issues with scaling and DNS_PING. Here are the changes we had to make to get it working.

Previous experiments with autoscaling keycloak did not go well but the scaling policies in Kubernetes 1.18 as well as KUBE_PING seem to be the answer :smile: 

https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior