### PR TITLE
[mailhog] Add extra annotations and securityContext

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 3.2.2
+version: 3.2.3
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -7,6 +7,13 @@ metadata:
     helm.sh/chart: {{ include "mailhog.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.deploymentLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}    
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}    
 spec:
   selector:
     matchLabels:
@@ -68,6 +75,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}                
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -80,7 +91,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.auth.enabled }}
+    {{- if .Values.auth.enabled }}      
       volumes:
         - name: authdir
           secret:

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -25,6 +25,10 @@ securityContext:
   fsGroup: 1000
   runAsNonRoot: true
 
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  privileged: false
+  
 ingress:
   enabled: false
   annotations: {}
@@ -45,7 +49,11 @@ auth:
   fileName: auth.txt
   fileContents: ""
 
+deploymentAnnotations: {}
+
 podAnnotations: {}
+
+deploymentLabels: {}
 
 podLabels: {}
 


### PR DESCRIPTION
Hey guys!

To get the helm chart to pass a kube-score run, I needed to:

1. Add annotations to the deployment (not just the pod)
2. Add a securityContext to the container (not just the pod)

This PR adds both of these capabilities, while leaving everything else as-is ;)

Cheers!
D