### PR TITLE
add condition for ingress apiVersion

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.5.0
+version: 9.6.0
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,6 +1,10 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}


### PR DESCRIPTION
k8s < 1.14 only accept api version `extensions/v1beta1` for ingress:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/