### PR TITLE
[mailhog] Introduce `.Release.Namespace` in objects meta

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 3.2.2
+version: 3.3.0
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/templates/auth-secret.yaml
+++ b/charts/mailhog/templates/auth-secret.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ template "mailhog.authFileSecret" . }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   {{ .Values.auth.fileName }}: {{ .Values.auth.fileContents | b64enc }}

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     helm.sh/chart: {{ include "mailhog.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -9,8 +9,8 @@ metadata:
     helm.sh/chart: {{ include "mailhog.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- with .Values.ingress.annotations }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- with .Values.ingress.annotations }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/mailhog/templates/service.yaml
+++ b/charts/mailhog/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
     helm.sh/chart: {{ include "mailhog.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "{{ .Values.service.type }}"
   {{- with .Values.service.clusterIP }}


### PR DESCRIPTION
Description of the change

This PR adds .Release.Namespace to objects meta for Mailhog chart.

Benefits

Ability to use the helm chart when having declarative definition of all cluster objects rendered using helm template, for example in tools like Spinnaker.

Possible drawbacks

I don't see any, it will work as previously for helm install.

Signed-off-by: Bartosz Kondek <b.kondek@piwik.pro>