### PR TITLE
[keycloak] Allow setting loadBalancerSourceRanges on the svc

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.6.2
+version: 9.7.0
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -91,6 +91,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `service.labels` | Additional labels for headless and HTTP Services | `{}` |
 | `service.type` | The Service type | `ClusterIP` |
 | `service.loadBalancerIP` | Optional IP for the load balancer. Used for services of type LoadBalancer only | `""` |
+| `loadBalancerSourceRanges` | Optional List of allowed source ranges (CIDRs). Used for service of type LoadBalancer only | `[]`  |
 | `service.httpPort` | The http Service port | `80` |
 | `service.httpNodePort` | The HTTP Service node port if type is NodePort | `""` |
 | `service.httpsPort` | The HTTPS Service port | `8443` |

--- a/charts/keycloak/templates/service-http.yaml
+++ b/charts/keycloak/templates/service-http.yaml
@@ -19,6 +19,10 @@ spec:
   {{- if and (eq "LoadBalancer" .Values.service.type) .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq "LoadBalancer" .Values.service.type) .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.httpPort }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -274,6 +274,9 @@
           "extraPorts": {
             "type": "array"
           },
+          "loadBalancerSourceRanges": {
+            "type": "array"
+          },
           "httpNodePort": {
             "anyOf": [
               {

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -237,6 +237,10 @@ service:
   httpManagementNodePort: null
   # Additional Service ports, e. g. for custom admin console
   extraPorts: []
+  # When using Service type LoadBalancer, you can restrict source ranges allowed
+  # to connect to the LoadBalancer, e. g. will result in Security Groups
+  # (or equivalent) with inbound source ranges allowed to connect
+  loadBalancerSourceRanges: []
 
 ingress:
   # If `true`, an Ingress is created


### PR DESCRIPTION
When creating Service with type of LoadBalancer it results with Security
Group (or equivalent) open to 0.0.0.0/0. By allowing to define
`loadBalancerSourceRanges` one can limit that to a list of allowed
CIDRs. This is a must when a cloud policy of an organisation doesn't
allow opening security groups to 0.0.0.0/0.