### PR TITLE
[keycloak] Fix ingress

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.6.1
+version: 9.6.2
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -35,9 +35,19 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
             backend:
-              serviceName: {{ include "keycloak.fullname" $ }}-http
-              servicePort: {{ $ingress.servicePort }}
+              service:
+                name: {{ include "keycloak.fullname" $ }}-http
+                port:
+                  name: {{ $ingress.servicePort }}
+            {{- else }}
+            backend:
+              service:
+                serviceName: {{ include "keycloak.fullname" $ }}-http
+                servicePort: {{ $ingress.servicePort }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- end -}}


### PR DESCRIPTION
Currently, the helm chart fails when ingress is enabled. This pull request adapts ingress.yaml to ingress v1 syntax. Might be a good idea to add ingress deployment to automated testing.