### PR TITLE
[mailhog] add ability to set labels on the ingress object

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 3.3.0
+version: 3.3.1
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -9,6 +9,9 @@ metadata:
     helm.sh/chart: {{ include "mailhog.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.annotations }}
   annotations:

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -30,6 +30,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   hosts:
     - host: mailhog.example.com
       paths: ["/"]


### PR DESCRIPTION
Add possiblity to set labels on the ingress resource created. This is necessary e.g. when running multiple ingress controllers in a cluster which are using labelSelectors (as it is in our case)

Signed-off-by: Tobias Lolax <tobias.lolax@gmail.com>