### PR TITLE
[keycloak] fix: networking.k8s.io/v1/ingress check

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.8.0
+version: 9.8.1
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Create the service DNS name.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "keycloak.ingressAPIVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
             pathType: Prefix
             backend:
               service:
@@ -44,9 +44,8 @@ spec:
                   name: {{ $ingress.servicePort }}
             {{- else }}
             backend:
-              service:
-                serviceName: {{ include "keycloak.fullname" $ }}-http
-                servicePort: {{ $ingress.servicePort }}
+              serviceName: {{ include "keycloak.fullname" $ }}-http
+              servicePort: {{ $ingress.servicePort }}
             {{- end }}
           {{- end }}
     {{- end }}


### PR DESCRIPTION
Checking only `.Capabilities.APIVersions.Has "networking.k8s.io/v1"` was not sufficiënt. Improved by checking `.Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress"`.

The `backend` parts is also changed in v1, this is fixed now.

