### PR TITLE
[keycloak] Avoid issues with older K8s versions

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.8.1
+version: 9.8.2
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -153,7 +153,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.enableServiceLinks }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
enableServiceLinks was only introduced with K8s v1.13, which means the chart is incompatible with distributions that are still based on older versions (like OpenShift 3).

This commit changes the template to only render `enableServiceLinks` if it is enabled, allowing it the operator to disable it and restore pre-1.13 compatibility.

Fixes #358