### PR TITLE
[keycloak] fix networking.k8s.io/v1/Ingress API support

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.8.3
+version: 9.8.4
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Create the service DNS name.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "keycloak.ingressAPIVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/ingress" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
The fix introduced in #357 uses a lowercase check for the Ingress API `networking.k8s.io/v1/ingress` rather than `networking.k8s.io/v1/Ingress` which fails with a cluster version v1.19.3 like the one in the latest Docker Desktop.

This PR fixes that.