### PR TITLE
Add dots after extraInitContainers section

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.8.1
+version: 9.8.2
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -427,6 +427,8 @@ extraInitContainers: |
       - name: theme
         mountPath: /theme
 
+...
+
 extraVolumeMounts: |
   - name: theme
     mountPath: /opt/jboss/keycloak/themes/mytheme


### PR DESCRIPTION
I added dots to help others get the example section right. When I used the keycloak's values file I didn't notice extraVolumeMounts and extraVolumes sections at the bottom of the file.