### PR TITLE
[mailhog] Add imagePullSecrets to chart

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 3.3.0
+version: 3.4.0
 keywords:
   - mailhog
   - mail

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -43,6 +43,7 @@ Parameter | Description | Default
 `image.repository` | Docker image repository | `mailhog/mailhog`
 `image.tag` | Docker image tag whose default is the chart version | `""`
 `image.pullPolicy` | Docker image pull policy | `IfNotPresent`
+`imagePullSecrets` | Docker image pull secrets | `[]`
 `auth.enabled` | Specifies whether basic authentication is enabled, see [Auth.md](https://github.com/mailhog/MailHog/blob/master/docs/Auth.md) | `false`
 `auth.existingSecret` | If auth is enabled, uses an existing secret with this name; otherwise a secret is created | `""`
 `auth.fileName` | The name of the auth file | `auth.txt`

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "mailhog.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -3,6 +3,8 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Due to this whole Docker quota drama we are mirroring all images to private registry, so we need this setting configurable.

Signed-off-by: Konstanty Karagiorgis <k.karagiorgis@piwik.pro>