### PR TITLE
[keycloak] Allow NodePort with LoadBalancer

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.8.2
+version: 9.9.0
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/service-http.yaml
+++ b/charts/keycloak/templates/service-http.yaml
@@ -34,14 +34,14 @@ spec:
     - name: http
       port: {{ .Values.service.httpPort }}
       targetPort: http
-      {{- if and (eq "NodePort" .Values.service.type) .Values.service.httpNodePort }}
+      {{- if and (or (eq "NodePort" .Values.service.type) (eq "LoadBalancer" .Values.service.type) ) .Values.service.httpNodePort }}
       nodePort: {{ .Values.service.httpNodePort }}
       {{- end }}
       protocol: TCP
     - name: https
       port: {{ .Values.service.httpsPort }}
       targetPort: https
-      {{- if and (eq "NodePort" .Values.service.type) .Values.service.httpsNodePort }}
+      {{- if and (or (eq "NodePort" .Values.service.type) (eq "LoadBalancer" .Values.service.type) ) .Values.service.httpsNodePort }}
       nodePort: {{ .Values.service.httpsNodePort }}
       {{- end }}
       protocol: TCP


### PR DESCRIPTION
Similarly to Ingress-Nginx
(https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/templates/controller-service.yaml#L40-L48)
allow to set NodePort when Service of type LoadBalancer is used.
The use case for this is to allow using specific node port when Network
Load Balancer is used in AWS setup and a specific port needs to be used
for a case where security groups need to be managed outside of
Kubernets.