### PR TITLE
[keycloak] Allow overriding app version label

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.9.0
+version: 9.9.1
 appVersion: 11.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -37,9 +37,7 @@ Common labels
 {{- define "keycloak.labels" -}}
 helm.sh/chart: {{ include "keycloak.chart" . }}
 {{ include "keycloak.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
At the moment, the `app.kubernetes.io/version` label is always set to `.Chart.AppVersion`.

However, the keycloak app version string could also be overridden via `.Values.image.tag`. When this happens, the `app.kubernetes.io/version` will show an incorrect version string. This patch will update __helpers.tpl_ and allow it to also accept `.Values.image.tag` as the app version string if it is defined. 
