### PR TITLE
fix extraEnv, extraEnvFrom json mappings and render method for it in …

### DIFF
--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -99,12 +99,12 @@ spec:
                   name: {{ include "keycloak.postgresql.fullname" . }}
                   key: postgresql-password
             {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- tpl . $ | nindent 12 }}
-            {{- end }}
+            {{- with .Values.extraEnv -}}
+            {{- toYaml .  | nindent 12 }}
+            {{- end  }}
           envFrom:
             {{- with .Values.extraEnvFrom }}
-            {{- tpl . $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -56,10 +56,18 @@
       "type": "string"
     },
     "extraEnv": {
-      "type": "string"
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
     },
     "extraEnvFrom": {
-      "type": "string"
+      "type": "array"
     },
     "extraInitContainers": {
       "type": "string"

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -96,7 +96,7 @@ command: []
 args: []
 
 # Additional environment variables for Keycloak
-extraEnv: ""
+extraEnv: []
   # - name: KEYCLOAK_LOGLEVEL
   #   value: DEBUG
   # - name: WILDFLY_LOGLEVEL
@@ -107,7 +107,7 @@ extraEnv: ""
   #   value: "2"
 
 # Additional environment variables for Keycloak mapped from Secret or ConfigMap
-extraEnvFrom: ""
+extraEnvFrom: []
 
 #  Pod priority class name
 priorityClassName: ""


### PR DESCRIPTION
current values.json mapping of extraEnv and extraEnvFrom is String and it cannot be correctly mapped with Helm v3.5.1