### PR TITLE
[keycloak] Add env var in keycloak chart

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 9.9.5
+version: 9.9.6
 appVersion: 11.0.3
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -82,6 +82,10 @@ spec:
           {{- tpl . $ | nindent 12 }}
           {{- end }}
           env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{- if .Values.postgresql.enabled }}
             - name: DB_VENDOR
               value: postgres


### PR DESCRIPTION
jgroups-kubernetes performs KUBE_PING in KUBERNETES_NAMESPACE namespace.
If not specified, then it performs against default namespace.
We can set `KUBERNETES_NAMESPACE` env var in `extraEnv` but I think auto-set is more reasonable.

Before #372, clusterRole was provisioned so no need to set the `KUBERNETES_NAMESPACE` explicitly.
But now, need to specify it because role and rolebinding is provisioned.