### PR TITLE
[keycloak] Add ingress.console (#335)

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.0.0
+version: 10.1.0
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `service.sessionAffinityConfig` | sessionAffinityConfig for Service | `{}` |
 | `ingress.enabled` | If `true`, an Ingress is created | `false` |
 | `ingress.rules` | List of Ingress Ingress rule | see below |
-| `ingress.rules[0].host` | Host for the Ingress rule | `keycloak.example.com` |
+| `ingress.rules[0].host` | Host for the Ingress rule | `{{ .Release.Name }}.keycloak.example.com` |
 | `ingress.rules[0].paths` | Paths for the Ingress rule | `[/]` |
 | `ingress.servicePort` | The Service port targeted by the Ingress | `http` |
 | `ingress.annotations` | Ingress annotations | `{}` |
@@ -111,6 +111,11 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `ingress.tls` | TLS configuration | see below |
 | `ingress.tls[0].hosts` | List of TLS hosts | `[keycloak.example.com]` |
 | `ingress.tls[0].secretName` | Name of the TLS secret | `""` |
+| `ingress.console.enabled` | If `true`, an Ingress for the console is created | `false` |
+| `ingress.console.rules` | List of Ingress Ingress rule for the console | see below |
+| `ingress.console.rules[0].host` | Host for the Ingress rule for the console | `{{ .Release.Name }}.keycloak.example.com` |
+| `ingress.console.rules[0].paths` | Paths for the Ingress rule for the console | `[/auth/admin]` |
+| `ingress.console.annotations` | Ingress annotations for the console | `{}` |
 | `networkPolicy.enabled` | If true, the ingress network policy is deployed | `false`
 | `networkPolicy.extraFrom` | Allows to define allowed external traffic (see Kubernetes doc for network policy `from` format) | `[]`
 | `route.enabled` | If `true`, an OpenShift Route is created | `false` |

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -49,4 +49,56 @@ spec:
             {{- end }}
           {{- end }}
     {{- end }}
+{{- if $ingress.console.enabled }}
+---
+apiVersion: {{ include "keycloak.ingressAPIVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "keycloak.fullname" . }}-console
+  {{- with $ingress.console.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+    {{- range $key, $value := $ingress.labels }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+spec:
+{{- if $ingress.tls }}
+  tls:
+    {{- range $ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ tpl . $ | quote }}
+      {{- end }}
+      {{- with .secretName }}
+      secretName: {{ tpl . $ }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+  rules:
+    {{- range .Values.ingress.console.rules }}
+    - host: {{ tpl .host $ | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "keycloak.fullname" $ }}-http
+                port:
+                  name: {{ $ingress.servicePort }}
+            {{- else }}
+            backend:
+              serviceName: {{ include "keycloak.fullname" $ }}-http
+              servicePort: {{ $ingress.servicePort }}
+            {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -275,6 +275,21 @@ ingress:
         - keycloak.example.com
       secretName: ""
 
+  # ingress for console only (/auth/admin)
+  console:
+    # If `true`, an Ingress is created for console path only
+    enabled: false
+    # Ingress annotations for console ingress only
+    # Useful to set nginx.ingress.kubernetes.io/whitelist-source-range particularly
+    annotations: {}
+    rules:
+      -
+        # Ingress host
+        host: '{{ .Release.Name }}.keycloak.example.com'
+        # Paths for the host
+        paths:
+          - /auth/admin/
+
 ## Network policy configuration
 networkPolicy:
   # If true, the Network policies are deployed


### PR DESCRIPTION
Add ingress.console part to create specific ingress for admin console access. This allow to have specific annotations for /auth/admin access such as `nginx.ingress.kubernetes.io/whitelist-source-range`

Signed-off-by: Olivier Boudet <o.boudet@gmail.com>