### PR TITLE
[keycloak] Add startupProbe

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.1.0
+version: 10.1.1
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.1.1
+version: 10.2.0
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.2.0
+version: 10.3.0
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -76,9 +76,9 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `tolerations` | Node taints to tolerate | `[]` |
 | `podLabels` | Additional Pod labels | `{}` |
 | `podAnnotations` | Additional Pod annotations | `{}` |
-| `livenessProbe` | Liveness probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":300,"timeoutSeconds":5}` |
+| `livenessProbe` | Liveness probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":5}` |
 | `readinessProbe` | Readiness probe configuration | `{"httpGet":{"path":"/auth/realms/master","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":1}` |
-| `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/realms/master","port":"http"},"initialDelaySeconds":300,"timeoutSeconds":5}` |
+| `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":300,"timeoutSeconds":5}` |
 | `resources` | Pod resource requests and limits | `{}` |
 | `startupScripts` | Startup scripts to run before Keycloak starts up | `{"keycloak.cli":"{{- .Files.Get "scripts/keycloak.cli" \| nindent 2 }}"}` |
 | `extraVolumes` | Add additional volumes, e. g. for custom themes | `""` |

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `podAnnotations` | Additional Pod annotations | `{}` |
 | `livenessProbe` | Liveness probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":0,"timeoutSeconds":5}` |
 | `readinessProbe` | Readiness probe configuration | `{"httpGet":{"path":"/auth/realms/master","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":1}` |
-| `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":5, "failureThreshold": 30, "periodSeconds": 5}` |
+| `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":5, "failureThreshold": 60, "periodSeconds": 5}` |
 | `resources` | Pod resource requests and limits | `{}` |
 | `startupScripts` | Startup scripts to run before Keycloak starts up | `{"keycloak.cli":"{{- .Files.Get "scripts/keycloak.cli" \| nindent 2 }}"}` |
 | `extraVolumes` | Add additional volumes, e. g. for custom themes | `""` |
@@ -563,7 +563,7 @@ startupProbe: |
     port: http
   initialDelaySeconds: 30
   timeoutSeconds: 1
-  failureThreshold: 30
+  failureThreshold: 60
   periodSeconds: 5
 ```
 
@@ -731,7 +731,7 @@ startup probe was added in 10.2.0 and is configured as follows:
       port: http
     initialDelaySeconds: 30
     timeoutSeconds: 1
-    failureThreshold: 30
+    failureThreshold: 60
     periodSeconds: 5
 ```
 

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -76,9 +76,9 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `tolerations` | Node taints to tolerate | `[]` |
 | `podLabels` | Additional Pod labels | `{}` |
 | `podAnnotations` | Additional Pod annotations | `{}` |
-| `livenessProbe` | Liveness probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":5}` |
+| `livenessProbe` | Liveness probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":0,"timeoutSeconds":5}` |
 | `readinessProbe` | Readiness probe configuration | `{"httpGet":{"path":"/auth/realms/master","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":1}` |
-| `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":300,"timeoutSeconds":5}` |
+| `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":5, "failureThreshold": 30, "periodSeconds": 5}` |
 | `resources` | Pod resource requests and limits | `{}` |
 | `startupScripts` | Startup scripts to run before Keycloak starts up | `{"keycloak.cli":"{{- .Files.Get "scripts/keycloak.cli" \| nindent 2 }}"}` |
 | `extraVolumes` | Add additional volumes, e. g. for custom themes | `""` |
@@ -547,7 +547,7 @@ livenessProbe: |
   httpGet:
     path: {{ if ne .Values.contextPath "" }}/{{ .Values.contextPath }}{{ end }}/
     port: http
-  initialDelaySeconds: 300
+  initialDelaySeconds: 0
   timeoutSeconds: 5
 
 readinessProbe: |
@@ -556,9 +556,18 @@ readinessProbe: |
     port: http
   initialDelaySeconds: 30
   timeoutSeconds: 1
+
+startupProbe: |
+  httpGet:
+    path: /auth/
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 1
+  failureThreshold: 30
+  periodSeconds: 5
 ```
 
-The above YAML references introduces the custom value `contextPath` which is possible because `startupScripts`, `livenessProbe`, and `readinessProbe` are templated using the `tpl` function.
+The above YAML references introduces the custom value `contextPath` which is possible because `startupScripts`, `livenessProbe`, `readinessProbe`, and `startupProbe` are templated using the `tpl` function.
 Note that it must not start with a slash.
 Alternatively, you may supply it via CLI flag:
 
@@ -711,6 +720,19 @@ The defaults are unchanged, but since 6.0.0 configured as follows:
       port: http
     initialDelaySeconds: 30
     timeoutSeconds: 1
+```
+
+startup probe was added in 10.2.0 and is configured as follows:
+
+```yaml
+  startupProbe: |
+    httpGet:
+      path: /auth/
+      port: http
+    initialDelaySeconds: 30
+    timeoutSeconds: 1
+    failureThreshold: 30
+    periodSeconds: 5
 ```
 
 #### Changes in Existing Secret Configuration

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -76,8 +76,9 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `tolerations` | Node taints to tolerate | `[]` |
 | `podLabels` | Additional Pod labels | `{}` |
 | `podAnnotations` | Additional Pod annotations | `{}` |
-| `livenessProbe` | Liveness probe configuration | `{"httpGet":{"path":"/health/live","port":"http"},"initialDelaySeconds":300,"timeoutSeconds":5}` |
+| `livenessProbe` | Liveness probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":300,"timeoutSeconds":5}` |
 | `readinessProbe` | Readiness probe configuration | `{"httpGet":{"path":"/auth/realms/master","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":1}` |
+| `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/realms/master","port":"http"},"initialDelaySeconds":300,"timeoutSeconds":5}` |
 | `resources` | Pod resource requests and limits | `{}` |
 | `startupScripts` | Startup scripts to run before Keycloak starts up | `{"keycloak.cli":"{{- .Files.Get "scripts/keycloak.cli" \| nindent 2 }}"}` |
 | `extraVolumes` | Add additional volumes, e. g. for custom themes | `""` |
@@ -203,6 +204,7 @@ It is used for the following values:
 * `extraVolumes`
 * `livenessProbe`
 * `readinessProbe`
+* `startupProbe`
 
 Additionally, custom labels and annotations can be set on various resources the values of which being passed through `tpl` as well.
 

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -127,6 +127,10 @@ spec:
           readinessProbe:
             {{- tpl . $ | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -166,6 +166,14 @@ readinessProbe: |
   initialDelaySeconds: 30
   timeoutSeconds: 1
 
+# Startup probe configuration
+startupProbe: |
+  httpGet:
+    path: /auth/realms/master
+    port: http
+  initialDelaySeconds: 300
+  timeoutSeconds: 1
+
 # Pod resource requests and limits
 resources: {}
   # requests:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -173,7 +173,7 @@ startupProbe: |
     port: http
   initialDelaySeconds: 30
   timeoutSeconds: 1
-  failureThreshold: 30
+  failureThreshold: 60
   periodSeconds: 5
 
 # Pod resource requests and limits

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -155,7 +155,7 @@ livenessProbe: |
   httpGet:
     path: /auth/
     port: http
-  initialDelaySeconds: 300
+  initialDelaySeconds: 5
   timeoutSeconds: 5
 
 # Readiness probe configuration
@@ -163,16 +163,16 @@ readinessProbe: |
   httpGet:
     path: /auth/realms/master
     port: http
-  initialDelaySeconds: 30
+  initialDelaySeconds: 5
   timeoutSeconds: 1
 
 # Startup probe configuration
 startupProbe: |
   httpGet:
-    path: /auth/realms/master
+    path: /auth/
     port: http
-  initialDelaySeconds: 300
-  timeoutSeconds: 1
+  initialDelaySeconds: 150
+  timeoutSeconds: 5
 
 # Pod resource requests and limits
 resources: {}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -155,7 +155,7 @@ livenessProbe: |
   httpGet:
     path: /auth/
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 0
   timeoutSeconds: 5
 
 # Readiness probe configuration
@@ -163,7 +163,7 @@ readinessProbe: |
   httpGet:
     path: /auth/realms/master
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   timeoutSeconds: 1
 
 # Startup probe configuration
@@ -171,8 +171,10 @@ startupProbe: |
   httpGet:
     path: /auth/
     port: http
-  initialDelaySeconds: 150
-  timeoutSeconds: 5
+  initialDelaySeconds: 30
+  timeoutSeconds: 1
+  failureThreshold: 30
+  periodSeconds: 5
 
 # Pod resource requests and limits
 resources: {}


### PR DESCRIPTION
Since Keycloak takes a significant amount of time to start up, it is helpful to have startupProbe to find out when it's ready to receive connections.