### PR TITLE
[mailhog] Add Outgoing SMTP config

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 4.0.0
+version: 4.0.1
 type: application
 keywords:
   - mailhog

--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 4.0.1
+version: 4.1.0
 type: application
 keywords:
   - mailhog

--- a/charts/mailhog/templates/_helpers.tpl
+++ b/charts/mailhog/templates/_helpers.tpl
@@ -70,3 +70,14 @@ Create the name for the auth secret.
         {{- template "mailhog.fullname" . -}}-auth
     {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name for the outgoing-smtp secret.
+*/}}
+{{- define "mailhog.outgoingSMTPSecret" -}}
+    {{- if .Values.outgoingSMTP.existingSecret -}}
+        {{- .Values.outgoingSMTP.existingSecret -}}
+    {{- else -}}
+        {{- template "mailhog.fullname" . -}}-outgoing-smtp
+    {{- end -}}
+{{- end -}}

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             {{- end }}
             {{- if .Values.outgoingSMTP.enabled }}
             - name: MH_OUTGOING_SMTP
-              value: /home/mailhog/{{ .Values.outgoingSMTP.fileName }}
+              value: /config/{{ .Values.outgoingSMTP.fileName }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - name: MH_AUTH_FILE
               value: /authdir/{{ .Values.auth.fileName }}
             {{- end }}
+            {{- if .Values.outgoingSMTP.enabled }}
+            - name: MH_OUTGOING_SMTP
+              value: /config/{{ .Values.outgoingSMTP.fileName }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -66,6 +70,12 @@ spec:
           volumeMounts:
             - name: authdir
               mountPath: /authdir
+              readOnly: true
+          {{- end }}
+          {{- if .Values.outgoingSMTP.enabled }}
+          volumeMounts:
+            - name: outsmtpdir
+              mountPath: /config
               readOnly: true
           {{- end }}
           {{- with .Values.containerSecurityContext }}
@@ -91,4 +101,10 @@ spec:
         - name: authdir
           secret:
             secretName: {{ template "mailhog.authFileSecret" . }}
+      {{- end }}
+      {{- if .Values.outgoingSMTP.enabled }}
+      volumes:
+        - name: outsmtpdir
+          secret:
+            secretName: {{ template "mailhog.outgoingSMTPSecret" . }}
       {{- end }}

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             {{- end }}
             {{- if .Values.outgoingSMTP.enabled }}
             - name: MH_OUTGOING_SMTP
-              value: /config/{{ .Values.outgoingSMTP.fileName }}
+              value: /home/mailhog/{{ .Values.outgoingSMTP.fileName }}
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/mailhog/templates/smtp-secret.yaml
+++ b/charts/mailhog/templates/smtp-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.outgoingSMTP.enabled) (not .Values.outgoingSMTP.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "mailhog.labels" . | nindent 4 }}
+  name: {{ template "mailhog.outgoingSMTPSecret" . }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  {{ .Values.outgoingSMTP.fileName }}: {{ .Values.outgoingSMTP.fileContents | toJson | b64enc }}
+{{- end -}}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -68,6 +68,27 @@ auth:
   fileName: auth.txt
   fileContents: ""
 
+outgoingSMTP:
+  enabled: false
+  existingSecret: ""
+  fileName: outgoing-smtp.json
+  fileContents:
+    # See https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md#outgoing-smtp-configuration
+    # Only name, host and port are required.
+    #
+    server_name1:
+      name: server_name1
+      host: mail.example.com
+      port: 25
+      #email: ""
+      #username: ""
+      #password: ""
+      #mechanism: "PLAIN|CRAM-MD5"
+    #server_name2:
+    #  name: server_name2
+    #  host: mail2.example.com
+    #  port: 587
+
 podAnnotations: {}
 
 podLabels: {}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -78,17 +78,17 @@ outgoingSMTP:
     # Only name, host and port are required.
     #
     # server_name1:
-    #   name: server_name1
-    #   host: mail.example.com
-    #   port: 25
+    #   name: "server_name1"
+    #   host: "mail.example.com"
+    #   port: "25"    # NOTE: go requires this port number to be a string... otherwise the container won't start
     #   email: ""
     #   username: ""
     #  password: ""
     #  mechanism: "PLAIN|CRAM-MD5"
     # server_name2:
-    #   name: server_name2
-    #   host: mail2.example.com
-    #   port: 587
+    #   name: "server_name2"
+    #   host: "mail2.example.com"
+    #   port: "587"   # NOTE: go requires this port number to be a string... otherwise the container won't start
 
 podAnnotations: {}
 

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -68,6 +68,7 @@ auth:
   fileName: auth.txt
   fileContents: ""
 
+# JSON file defining outgoing SMTP servers
 outgoingSMTP:
   enabled: false
   existingSecret: ""

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -81,14 +81,14 @@ outgoingSMTP:
       name: server_name1
       host: mail.example.com
       port: 25
-      #email: ""
-      #username: ""
-      #password: ""
-      #mechanism: "PLAIN|CRAM-MD5"
-    #server_name2:
-    #  name: server_name2
-    #  host: mail2.example.com
-    #  port: 587
+      # email: ""
+      # username: ""
+      # password: ""
+      # mechanism: "PLAIN|CRAM-MD5"
+    # server_name2:
+    #   name: server_name2
+    #   host: mail2.example.com
+    #   port: 587
 
 podAnnotations: {}
 

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -73,18 +73,18 @@ outgoingSMTP:
   enabled: false
   existingSecret: ""
   fileName: outgoing-smtp.json
-  fileContents:
+  fileContents: {}
     # See https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md#outgoing-smtp-configuration
     # Only name, host and port are required.
     #
-    server_name1:
-      name: server_name1
-      host: mail.example.com
-      port: 25
-      # email: ""
-      # username: ""
-      # password: ""
-      # mechanism: "PLAIN|CRAM-MD5"
+    # server_name1:
+    #   name: server_name1
+    #   host: mail.example.com
+    #   port: 25
+    #   email: ""
+    #   username: ""
+    #  password: ""
+    #  mechanism: "PLAIN|CRAM-MD5"
     # server_name2:
     #   name: server_name2
     #   host: mail2.example.com


### PR DESCRIPTION
Add config to add permanent outgoing-smtp config using a secret analogue to the auth secret.