### PR TITLE
[keycloak] increase pgchecker resources

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.1.2
+version: 10.3.1
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.1.0
+version: 10.1.1
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.1.1
+version: 10.1.2
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -339,11 +339,11 @@ pgchecker:
   # Resource requests and limits for the pgchecker container
   resources:
     requests:
-      cpu: "10m"
-      memory: "16Mi"
+      cpu: "20m"
+      memory: "32Mi"
     limits:
-      cpu: "10m"
-      memory: "16Mi"
+      cpu: "20m"
+      memory: "32Mi"
 
 postgresql:
   # If `true`, the Postgresql dependency is enabled


### PR DESCRIPTION
Greetings codecentric,

I was trying to use your Keycloak charts with minikube and I got this error. After looking why this chart was failing I found out that the pgchecker assigned resources were too low. Also you can use a custom values.yml file to fix this but I think It will be better if the Keycloak chart has this covered from its default values.

Steps to reproduce:
 - `helm install keycoak codecentric/keycloak`
 - `kubectl describe pod keycloak-0`

```
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  82s                default-scheduler  Successfully assigned default/keycloak-0 to minikube
  Warning  Failed     76s                kubelet            Error: failed to start container "pgchecker": Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: process_linux.go:459: container init caused: read init-p: connection reset by peer: unknown
  Normal   Pulled     31s (x4 over 81s)  kubelet            Container image "docker.io/busybox:1.32" already present on machine
  Normal   Created    31s (x4 over 81s)  kubelet            Created container pgchecker
  Warning  Failed     29s (x3 over 80s)  kubelet            Error: failed to start container "pgchecker": Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: process_linux.go:338: getting the final child's pid from pipe caused: read init-p: connection reset by peer: unknown
  Warning  BackOff    0s (x6 over 57s)   kubelet            Back-off restarting failed container
```