### PR TITLE
[keycloak] Adding externalTrafficPolicy to service definitions

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 10.1.0
+version: 10.2.0
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `service.type` | The Service type | `ClusterIP` |
 | `service.loadBalancerIP` | Optional IP for the load balancer. Used for services of type LoadBalancer only | `""` |
 | `loadBalancerSourceRanges` | Optional List of allowed source ranges (CIDRs). Used for service of type LoadBalancer only | `[]`  |
+| `service.externalTrafficPolicy` | Optional external traffic policy. Used for services of type LoadBalancer only | `"Cluster"` |
 | `service.httpPort` | The http Service port | `80` |
 | `service.httpNodePort` | The HTTP Service node port if type is NodePort | `""` |
 | `service.httpsPort` | The HTTPS Service port | `8443` |

--- a/charts/keycloak/templates/service-http.yaml
+++ b/charts/keycloak/templates/service-http.yaml
@@ -23,6 +23,9 @@ spec:
   loadBalancerSourceRanges:
     {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if eq "LoadBalancer" .Values.service.type }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
     {{- with .Values.service.sessionAffinityConfig }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -242,6 +242,10 @@ service:
   # to connect to the LoadBalancer, e. g. will result in Security Groups
   # (or equivalent) with inbound source ranges allowed to connect
   loadBalancerSourceRanges: []
+  # When using Service type LoadBalancer, you can preserve the source IP seen in the container
+  # by changing the default (Cluster) to be Local.
+  # See https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  externalTrafficPolicy: "Cluster"
   # Session affinity
   # See https://kubernetes.io/docs/concepts/services-networking/service/#proxy-mode-userspace
   sessionAffinity: ""


### PR DESCRIPTION
This PR allows the deployment to explicitly set the externalTrafficPolicy when deploying a service type 'LoadBalancer', allowing the default value of Cluster to be changed to Local as part of the chart provisioning of the load balanced service.