### PR TITLE
[mailhog] Fix to enable outgoingSMTP and auth

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 4.1.0
+version: 4.1.1
 type: application
 keywords:
   - mailhog

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -66,14 +66,13 @@ spec:
           readinessProbe:
             tcpSocket:
               port: tcp-smtp
-          {{- if .Values.auth.enabled }}
           volumeMounts:
+          {{- if .Values.auth.enabled }}
             - name: authdir
               mountPath: /authdir
               readOnly: true
           {{- end }}
           {{- if .Values.outgoingSMTP.enabled }}
-          volumeMounts:
             - name: outsmtpdir
               mountPath: /config
               readOnly: true
@@ -96,14 +95,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.auth.enabled }}
       volumes:
+      {{- if .Values.auth.enabled }}
         - name: authdir
           secret:
             secretName: {{ template "mailhog.authFileSecret" . }}
       {{- end }}
       {{- if .Values.outgoingSMTP.enabled }}
-      volumes:
         - name: outsmtpdir
           secret:
             secretName: {{ template "mailhog.outgoingSMTPSecret" . }}


### PR DESCRIPTION
Currently outgoingSMTP and auth cannot be enabled at the same time, as the keys are overwriting themselves. THis MR should fix it.