### PR TITLE
[keycloak] Fix container ports in network policy

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 11.0.0
+version: 11.0.1
 appVersion: 12.0.4
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/networkpolicy.yaml
+++ b/charts/keycloak/templates/networkpolicy.yaml
@@ -20,9 +20,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       ports:
         - protocol: TCP
-          port: {{ $.Values.service.httpPort }}
+          port: 8080
         - protocol: TCP
-          port: {{ $.Values.service.httpsPort }}
+          port: 8443
         {{ range $.Values.extraPorts }}
         - protocol: {{ default "TCP" .protocol }}
           port: {{ .containerPort }}
@@ -34,11 +34,11 @@ spec:
               {{- include "keycloak.selectorLabels" . | nindent 14 }}
       ports:
         - protocol: TCP
-          port: {{ .Values.service.httpPort }}
+          port: 8080
         - protocol: TCP
-          port: {{ .Values.service.httpsPort }}
+          port: 8443
         - protocol: TCP
-          port: {{ .Values.service.httpManagementPort }}
+          port: 9990
         {{ range .Values.extraPorts }}
         - protocol: {{ default "TCP" .protocol }}
           port: {{ .containerPort }}


### PR DESCRIPTION
Network policies operate on the pod level, not the service. 
Allowing (previous default) port 80 from service doesn't work, since container listens on 8080.

(Since the container port isn't configurable in the values.yaml, I also hardcoded those in the netpol template.)