### PR TITLE
[keycloak] Allow templating in prometheus rules

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 14.0.1
+version: 14.1.0
 appVersion: 14.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/prometheusrule.yaml
+++ b/charts/keycloak/templates/prometheusrule.yaml
@@ -19,6 +19,14 @@ spec:
   groups:
     - name: {{ include "keycloak.fullname" $ }}
       rules:
+        {{- with .rules }}
         {{- toYaml .rules | nindent 8 }}
+        {{- end }}
+        {{- with .rulesTemplate }}
+        {{- range . }}
+        -
+          {{- (tpl (. | toYaml) $) | nindent 10 }}
+        {{- end }}
+        {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Most of monitoring rules are namespace dependent.
When we have two instances of keycloak chart on one cluster and we want to share our monitoring rules across these chart instances, we need to have templating capabilities.

Signed-off-by: Julien Bouyoud <jBouyoud@users.noreply.github.com>
