### PR TITLE
[keycloak] separated console tls hosts and secrets

### DIFF
--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -116,8 +116,10 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `ingress.tls[0].hosts` | List of TLS hosts | `[keycloak.example.com]` |
 | `ingress.tls[0].secretName` | Name of the TLS secret | `""` |
 | `ingress.console.enabled` | If `true`, an Ingress for the console is created | `false` |
+| `ingress.console.tls[0].hosts` | List of TLS hosts for the console | `[admin.anotherexample.com]` |
+| `ingress.console.tls[0].secretName` | Name of the TLS secret for the console | `""` |
 | `ingress.console.rules` | List of Ingress Ingress rule for the console | see below |
-| `ingress.console.rules[0].host` | Host for the Ingress rule for the console | `{{ .Release.Name }}.keycloak.example.com` |
+| `ingress.console.rules[0].host` | Host for the Ingress rule for the console | `{{ .Release.Name }}.admin.anotherexample.com` |
 | `ingress.console.rules[0].paths` | Paths for the Ingress rule for the console | see below |
 | `ingress.console.rules[0].paths[0].path` | Path for the Ingress rule for the console | `[/auth/admin]` |
 | `ingress.console.rules[0].paths[0].pathType` | Path Type for the Ingress rule for the console | `Prefix` |

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -67,9 +67,9 @@ metadata:
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
 spec:
-{{- if $ingress.tls }}
+{{- if $ingress.console.tls }}
   tls:
-    {{- range $ingress.tls }}
+    {{- range $ingress.console.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ tpl . $ | quote }}


### PR DESCRIPTION
Hey
It might be a good idea if we can separate TLS hosts and secrets for the console ingress.


Signed-off-by: Alireza Davoodi <davoodi@fd.nl>