### PR TITLE
[mailhog] add support for ingress v1

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 4.1.0
+version: 5.0.0
 type: application
 keywords:
   - mailhog

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -71,6 +71,36 @@ Parameter | Description | Default
 `ingress.enabled` | If `true`, an ingress is created | `false`
 `ingress.annotations` | Annotations for the ingress | `{}`
 `ingress.labels` | Labels for the ingress | `{}`
-`ingress.hosts` | A list of ingress hosts | `{ host: mailhog.example.com, paths: ["/"] }`
+`ingress.hosts` | A list of ingress hosts | `{ host: mailhog.example.com, paths: [{ path: "/", pathType: Prefix }] }`
 `ingress.tls` | A list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
 `extraEnv` | Additional environment variables, see [CONFIG.md](https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md) | `{}`
+
+## Upgrading
+
+### From chart < 5.0.0
+
+ Ingress path definitions are extended to describe path and pathType. Previously only the path was configured. Please adapt your configuration as shown below:
+
+ Old:
+ ```yaml
+ ingress:
+   # ...
+   hosts:
+     - host: mailhog.example.com
+       # Paths for the host
+       paths:
+         - /
+ ```
+ New:
+ ```yaml
+ ingress:
+   # ...
+   hosts:
+     - host: mailhog.example.com
+       # Paths for the host
+       paths:
+         - path: /
+           pathType: Prefix
+ ```
+
+ This allows to configure specific `pathType` configurations, e.g. `pathType: ImplementationSpecific` for [GKE Ingress on Google Cloud Platform](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend).

--- a/charts/mailhog/templates/_helpers.tpl
+++ b/charts/mailhog/templates/_helpers.tpl
@@ -81,3 +81,14 @@ Create the name for the outgoing-smtp secret.
         {{- template "mailhog.fullname" . -}}-outgoing-smtp
     {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "mailhog.ingressAPIVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mailhog.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "mailhog.ingressAPIVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,10 +33,19 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -55,7 +55,10 @@ ingress:
   labels: {}
   hosts:
     - host: mailhog.example.com
-      paths: ["/"]
+      paths:
+        - path: "/"
+          pathType: Prefix
+
 
   tls: []
   #  - secretName: chart-example-tls


### PR DESCRIPTION
This PR adds support Ingress in ApiVersion networking.k8s.io/v1 as networking.k8s.io/v1beta1 is now deprecated. Ports PRs #334  #357 #360 and #450 to the Mailhog chart.