### PR TITLE
[keycloak] fix http port in case of reencrypt of passthrough

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 15.0.2
+version: 15.0.3
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/route.yaml
+++ b/charts/keycloak/templates/route.yaml
@@ -21,7 +21,11 @@ spec:
 {{- end }}
   path: {{ $route.path }}
   port:
+    {{- if or (not $route.tls.enabled) (eq $route.tls.termination "edge") }}
     targetPort: http
+    {{- else}}
+    targetPort: https
+    {{- end}}
   to:
     kind: Service
     name: {{ include "keycloak.fullname" $ }}-http


### PR DESCRIPTION
The port stays to "http" in case of reencrypt of passthrough, fixed that