### PR TITLE
[keycloak] extraEnv substitution (feature request) #459

### DIFF
--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -68,8 +68,8 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `clusterDomain` | The internal Kubernetes cluster domain | `cluster.local` |
 | `command` | Overrides the default entrypoint of the Keycloak container | `[]` |
 | `args` | Overrides the default args for the Keycloak container | `[]` |
-| `extraEnv` | Additional environment variables for Keycloak | `""` |
-| `extraEnvFrom` | Additional environment variables for Keycloak mapped from a Secret or ConfigMap | `""` |
+| `extraEnv` | Additional environment variables for Keycloak | `[]` |
+| `extraEnvFrom` | Additional environment variables for Keycloak mapped from a Secret or ConfigMap | `[]` |
 | `priorityClassName` | Pod priority class name | `""` |
 | `affinity` | Pod affinity | Hard node and soft zone anti-affinity |
 | `nodeSelector` | Node labels for Pod assignment | `{}` |
@@ -81,8 +81,8 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `startupProbe` | Startup probe configuration | `{"httpGet":{"path":"/auth/","port":"http"},"initialDelaySeconds":30,"timeoutSeconds":5, "failureThreshold": 60, "periodSeconds": 5}` |
 | `resources` | Pod resource requests and limits | `{}` |
 | `startupScripts` | Startup scripts to run before Keycloak starts up | `{"keycloak.cli":"{{- .Files.Get "scripts/keycloak.cli" \| nindent 2 }}"}` |
-| `extraVolumes` | Add additional volumes, e. g. for custom themes | `""` |
-| `extraVolumeMounts` | Add additional volumes mounts, e. g. for custom themes | `""` |
+| `extraVolumes` | Add additional volumes, e. g. for custom themes | `[]` |
+| `extraVolumeMounts` | Add additional volumes mounts, e. g. for custom themes | `[]` |
 | `extraPorts` | Add additional ports, e. g. for admin console or exposing JGroups ports | `[]` |
 | `podDisruptionBudget` | Pod disruption budget | `{}` |
 | `statefulsetAnnotations` | Annotations for the StatefulSet | `{}` |
@@ -652,7 +652,7 @@ The headless service that governs the StatefulSet is used for DNS discovery via 
 
 ### From chart < 14.0.0
 
-Ingress path definitions are extended to describe path and pathType. Previously only the path was configured. Please adapt your configuration as shown below:  
+Ingress path definitions are extended to describe path and pathType. Previously only the path was configured. Please adapt your configuration as shown below:
 
 Old:
 ```yaml
@@ -682,19 +682,19 @@ This allows to configure specific `pathType` configurations, e.g. `pathType: Imp
 
 * Keycloak is updated to 14.0.0
 
-Note that this might not be a seamless upgrade, because the clustering with older Keycloak versions might not work 
+Note that this might not be a seamless upgrade, because the clustering with older Keycloak versions might not work
 due to incompatible infinispan versions.
 
 ### From chart < 12.0.0
 
 * Keycloak is updated to 13.0.1
 
-Note that this might not be a seamless upgrade, because the clustering with older Keycloak versions might not work 
+Note that this might not be a seamless upgrade, because the clustering with older Keycloak versions might not work
 due to incompatible infinispan versions.
 
 One way to perform the upgrade is to run:
 ```
-kubectl delete sts <RELEASE_NAME>-keycloak && helm upgrade --install 
+kubectl delete sts <RELEASE_NAME>-keycloak && helm upgrade --install
 ```
 This ensures that all replicas are restarted with the same version.
 Note that all sessions are lost in this case, and users might need to login again.

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
             {{- toYaml .Values.pgchecker.resources | nindent 12 }}
         {{- end }}
         {{- with .Values.extraInitContainers }}
-        {{- tpl . $ | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
@@ -79,7 +79,7 @@ spec:
             {{- toYaml .Values.args | nindent 12 }}
           {{- with .Values.lifecycleHooks }}
           lifecycle:
-          {{- tpl . $ | nindent 12 }}
+          {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           env:
             {{- if .Values.postgresql.enabled }}
@@ -100,11 +100,11 @@ spec:
                   key: postgresql-password
             {{- end }}
             {{- with .Values.extraEnv }}
-            {{- tpl . $ | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           envFrom:
             {{- with .Values.extraEnvFrom }}
-            {{- tpl . $ | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           ports:
             - name: http
@@ -121,15 +121,15 @@ spec:
             {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- tpl . $ | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- tpl . $ | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.startupProbe }}
           startupProbe:
-            {{- tpl . $ | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -141,10 +141,10 @@ spec:
               readOnly: true
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
-            {{- tpl . $ | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
         {{- with .Values.extraContainers }}
-        {{- tpl . $ | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -188,5 +188,5 @@ spec:
               {{- end }}
         {{- end }}
         {{- with .Values.extraVolumes }}
-        {{- tpl . $ | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -53,25 +53,25 @@
       "type": "boolean"
     },
     "extraContainers": {
-      "type": "string"
+      "type": "array"
     },
     "extraEnv": {
-      "type": "string"
+      "type": "array"
     },
     "extraEnvFrom": {
-      "type": "string"
+      "type": "array"
     },
     "extraInitContainers": {
-      "type": "string"
+      "type": "array"
     },
     "extraPorts": {
       "type": "array"
     },
     "extraVolumeMounts": {
-      "type": "string"
+      "type": "array"
     },
     "extraVolumes": {
-      "type": "string"
+      "type": "array"
     },
     "fullnameOverride": {
       "type": "string"
@@ -153,10 +153,10 @@
         }
       },
       "lifecycleHooks": {
-        "type": "string"
+        "type": "object"
       },
       "livenessProbe": {
-        "type": "string"
+        "type": "array"
       },
       "nameOverride": {
         "type": "string"
@@ -233,7 +233,10 @@
         "type": "object"
       },
       "readinessProbe": {
-        "type": "string"
+        "type": "array"
+      },
+      "startupProbe": {
+        "type": "array"
       },
       "replicas": {
         "type": "integer"

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -69,13 +69,13 @@ securityContext:
   runAsNonRoot: true
 
 # Additional init containers, e. g. for providing custom themes
-extraInitContainers: ""
+extraInitContainers: []
 
 # Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy
-extraContainers: ""
+extraContainers: []
 
 # Lifecycle hooks for the Keycloak container
-lifecycleHooks: |
+lifecycleHooks: {}
 #  postStart:
 #    exec:
 #      command:
@@ -96,18 +96,18 @@ command: []
 args: []
 
 # Additional environment variables for Keycloak
-extraEnv: ""
-  # - name: KEYCLOAK_LOGLEVEL
-  #   value: DEBUG
-  # - name: WILDFLY_LOGLEVEL
-  #   value: DEBUG
-  # - name: CACHE_OWNERS_COUNT
-  #   value: "2"
-  # - name: CACHE_OWNERS_AUTH_SESSIONS_COUNT
-  #   value: "2"
+extraEnv: []
+#  - name: KEYCLOAK_LOGLEVEL
+#    value: DEBUG
+#  - name: WILDFLY_LOGLEVEL
+#    value: DEBUG
+#  - name: CACHE_OWNERS_COUNT
+#    value: "2"
+#  - name: CACHE_OWNERS_AUTH_SESSIONS_COUNT
+#    value: "2"
 
 # Additional environment variables for Keycloak mapped from Secret or ConfigMap
-extraEnvFrom: ""
+extraEnvFrom: []
 
 #  Pod priority class name
 priorityClassName: ""
@@ -151,7 +151,7 @@ podLabels: {}
 podAnnotations: {}
 
 # Liveness probe configuration
-livenessProbe: |
+livenessProbe:
   httpGet:
     path: /auth/
     port: http
@@ -159,7 +159,7 @@ livenessProbe: |
   timeoutSeconds: 5
 
 # Readiness probe configuration
-readinessProbe: |
+readinessProbe:
   httpGet:
     path: /auth/realms/master
     port: http
@@ -167,7 +167,7 @@ readinessProbe: |
   timeoutSeconds: 1
 
 # Startup probe configuration
-startupProbe: |
+startupProbe:
   httpGet:
     path: /auth/
     port: http
@@ -196,10 +196,10 @@ startupScripts:
   # echo 'Hello from my custom startup script!'
 
 # Add additional volumes, e. g. for custom themes
-extraVolumes: ""
+extraVolumes: []
 
 # Add additional volumes mounts, e. g. for custom themes
-extraVolumeMounts: ""
+extraVolumeMounts: []
 
 # Add additional ports, e. g. for admin console or exposing JGroups ports
 extraPorts: []


### PR DESCRIPTION
## Convert previous parameters which take in multi-line `string` instead of `array` or `object`
Result example:
```yaml
extraEnv:
  - name: KEYCLOAK_LOGLEVEL
    value: DEBUG
  - name: WILDFLY_LOGLEVEL
    value: DEBUG
```
Such change will allow partial override of `extraEnv`, where currently `extraEnv: |` will have to override all of its child values.

## Changes apply to the following parameters:
- livenessProbe
- readinessProbe
- startupProbe
- extraInitContainers
- extraContainers
- lifecycleHooks
- extraEnv
- extraEnvFrom
- extraVolumes
- extraVolumeMounts

## **Known Issues (Two so far):**

1. Parameter `affinity` is left unchanged due the an error caused by
  ```yaml
   `{{- include "keycloak.selectorLabels" . | nindent 10 }}`
  ```
  > Error: cannot load values.yaml: error converting YAML to JSON: yaml: line 120: did not find expected node content


2. After the changes the values from template are missing the single-quote `' '`
  Input values:
  ```yaml
  - name: JGROUPS_DISCOVERY_PROPERTIES
    value: 'dns_query={{ include "keycloak.serviceDnsName" . }}'
  ```
   Outcome after update:
  ```yaml
  - name: JGROUPS_DISCOVERY_PROPERTIES
    value: dns_query=RELEASE-NAME-keycloa-headless.default.svc.cluster.local
  ```
  
   Original outcome:
  ```yaml
   - name: JGROUPS_DISCOVERY_PROPERTIES
     value: 'dns_query=RELEASE-NAME-keycloa-headless.default.svc.cluster.local'
  ```

**Please comment below if you have any concerns or suggestions about the changes.**