### PR TITLE
 [keycloak] fixing path and pathType in ingress

### DIFF
--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -85,9 +85,9 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ . }}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-            pathType: {{ .pathType }}
+            pathType: {{ . }}
             backend:
               service:
                 name: {{ include "keycloak.fullname" $ }}-http


### PR DESCRIPTION
We are getting error in ingress while deploying chart

```
Error: template: keycloak/templates/ingress.yaml:88:21: executing "keycloak/templates/ingress.yaml" at <.path>: can't evaluate field path in type interface {}
helm.go:88: [debug] template: keycloak/templates/ingress.yaml:88:21: executing "keycloak/templates/ingress.yaml" at <.path>: can't evaluate field path in type interface {}
```

So this Pr should solve this error