### PR TITLE
[keycloak] fix uncut version label

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 15.0.2
+version: 15.0.4
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 {{- define "keycloak.labels" -}}
 helm.sh/chart: {{ include "keycloak.chart" . }}
 {{ include "keycloak.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | trunc 63 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/keycloak/templates/route.yaml
+++ b/charts/keycloak/templates/route.yaml
@@ -21,7 +21,11 @@ spec:
 {{- end }}
   path: {{ $route.path }}
   port:
+    {{- if or (not $route.tls.enabled) (eq $route.tls.termination "edge") }}
     targetPort: http
+    {{- else}}
+    targetPort: https
+    {{- end}}
   to:
     kind: Service
     name: {{ include "keycloak.fullname" $ }}-http


### PR DESCRIPTION
We use sha256 image tags which are longer then allowed label length and caused a deployment error:
```
Invalid value: "52771198613a47a3c3a617937c137a61aa6591267ba6ee03f63ff04b61d5f3f8": must be no more than 63 characters
```
truncate the label after 63 characters.