### PR TITLE
[keycloak] fix(_helpers.tpl): redefine `keycloak.postgresql.fullname` to use postgresql replication setup

### DIFF
--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create a default fully qualified app name for the postgres requirement.
 */}}
 {{- define "keycloak.postgresql.fullname" -}}
 {{- $postgresContext := dict "Values" .Values.postgresql "Release" .Release "Chart" (dict "Name" "postgresql") -}}
-{{ include "keycloak.name" .}}-{{ include "postgresql.name" $postgresContext }}
+{{ include "keycloak.fullname" .}}-{{ include "postgresql.name" $postgresContext }}
 {{- end }}
 
 {{/*

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create a default fully qualified app name for the postgres requirement.
 */}}
 {{- define "keycloak.postgresql.fullname" -}}
 {{- $postgresContext := dict "Values" .Values.postgresql "Release" .Release "Chart" (dict "Name" "postgresql") -}}
-{{ include "postgresql.primary.fullname" $postgresContext }}
+{{ include "keycloak.name" .}}-{{ include "postgresql.name" $postgresContext }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
While testing the replication setup in postgresql with keycloak I found a bug in the chart that will occur in the `pgchecker` `initContainer` while waiting for the postgresql server to be up and running.

Indeed when using `postgresql.primary.fullname` we ended up having  `keycloak.postgresql.fullname` being set to `RELEASE-NAME-postgresql-primary` because of these [lines](https://github.com/bitnami/charts/blob/e34ee5c5aeafabe15cbf0d2b0fecb18483bc6415/bitnami/postgresql/templates/_helpers.tpl#L17-L18). Therefore the `pgchecker` container would never resolve `RELEASE-NAME-postgresql-primary` because no such service is deployed while using postgresql replication setup and just be stuck on `Init:0/1` because of hanging `nc -z -w 2 keycloak-postgresql-primary 5432` DB server check command.

I tested this fix with and without replication set, it works with both setup now.

Thanks for the concern of this fix.

Tell me if I am missing anything!

Signed-off-by: Valentin Maillot <valentin.maillot@adfinis.com>