### PR TITLE
[keycloak] feat: support helm chart version 2

### DIFF
--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 10.3.13
 digest: sha256:0b35e861ab4e49a0d63eb83bf74a753a4b12d576d2d5f941701a659b4c93e1e4
-generated: "2021-03-18T11:41:44.099229802+01:00"
+generated: "2021-10-02T08:07:05.761175+02:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 name: keycloak
-version: 15.1.0
+version: 16.0.0
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
@@ -21,3 +21,8 @@ maintainers:
     email: unguiculus@gmail.com
   - name: thomasdarimont
     email: thomas.darimont+github@gmail.com
+dependencies:
+  - name: postgresql
+    version: 10.3.13
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -19,6 +19,9 @@ For more information on Keycloak and its capabilities, see its [documentation](h
 The chart has an optional dependency on the [PostgreSQL](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) chart.
 By default, the PostgreSQL chart requires PV support on underlying infrastructure (may be disabled).
 
+**Important**
+Since Version `v16.0.0` the support for Helm v2 is dropped in favor of to support also the latest postgres Helm Chart Version which requires Helm v3 only.
+
 ## Installing the Chart
 
 To install the chart with the release name `keycloak`:

--- a/charts/keycloak/requirements.yaml
+++ b/charts/keycloak/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: postgresql
-    version: 10.3.13
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled


### PR DESCRIPTION
It fixes the problem of https://github.com/codecentric/helm-charts/blob/master/charts/keycloak/Chart.yaml#L1 is apiV1 and the Postgres dependency is already apiV2.


Closes #465