### PR TITLE
[keycloak] Add support for ingressClassName for k8s version <= 1.17

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 15.1.0
+version: 15.1.1
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,5 +1,10 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
+{{- if and $ingress.ingressClassName (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey $ingress.ingressClassName "kubernetes.io/ingress.class") }}
+  {{- $_ := set $ingress.annotations "kubernetes.io/ingress.class" $ingress.ingressClassName}}
+  {{- end }}
+{{- end }}
 apiVersion: {{ include "keycloak.ingressAPIVersion" . }}
 kind: Ingress
 metadata:
@@ -16,7 +21,7 @@ metadata:
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
 spec:
-{{- if $ingress.ingressClassName }}
+{{- if and $ingress.ingressClassName (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ $ingress.ingressClassName }}
 {{- end }}
 {{- if $ingress.tls }}


### PR DESCRIPTION
ingressClassName is supported only by k8s >=1.18. Previously, it was relying on annotations. Make it work transparently for older k8s version.