### PR TITLE
[keycloak] Allow ingress apiVersion to be specified directly in values.yaml instead of using Capabilities.

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 15.1.0
+version: 15.1.1
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -74,14 +74,3 @@ Create the service DNS name.
 {{- define "keycloak.serviceDnsName" -}}
 {{ include "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "keycloak.ingressAPIVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
-apiVersion: {{ include "keycloak.ingressAPIVersion" . }}
+apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}
@@ -54,7 +54,7 @@ spec:
     {{- end }}
 {{- if $ingress.console.enabled }}
 ---
-apiVersion: {{ include "keycloak.ingressAPIVersion" . }}
+apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}-console

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -268,6 +268,9 @@ service:
 ingress:
   # If `true`, an Ingress is created
   enabled: false
+  # Adjust as necessary for your current K8s version.
+  # If using K8s >= 1.22.x, change to networking.k8s.io/v1
+  apiVersion: networking.k8s.io/v1beta1
   # The name of the Ingress Class associated with this ingress
   ingressClassName: ""
   # The Service port targeted by the Ingress


### PR DESCRIPTION
Fix https://github.com/codecentric/helm-charts/issues/496

Signed-off-by: juliohm1978 <jhm@juliohm.com.br>