### PR TITLE
Change Ingress Api Version Logic

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak
-version: 15.1.0
+version: 15.1.1
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -74,14 +74,3 @@ Create the service DNS name.
 {{- define "keycloak.serviceDnsName" -}}
 {{ include "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
 {{- end }}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "keycloak.ingressAPIVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,15 +1,16 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
 {{- $apiV1 := false -}}
+{{- $apiVersion := "extensions/v1beta1" -}}
 {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0-0" .Capabilities.KubeVersion.Version) -}}
-  {{- $apiVersion := networking.k8s.io/v1 -}}
+  {{- $apiVersion := "networking.k8s.io/v1" -}}
   {{- $apiV1 = true -}}
 {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-  {{- $apiVersion := networking.k8s.io/v1beta1 -}}
+  {{- $apiVersion := "networking.k8s.io/v1beta1" -}}
 {{- else -}}
-  {{- $apiVersion := extensions/v1beta1 -}}
+  {{- $apiVersion := "extensions/v1beta1" -}}
 {{- end }}
-apiVersion: {{ $apiVersion }}
+apiVersion: {{ $apiVersion | quote }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,6 +1,15 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
-apiVersion: {{ include "keycloak.ingressAPIVersion" . }}
+{{- $apiV1 := false -}}
+{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0-0" .Capabilities.KubeVersion.Version) -}}
+  {{- $apiVersion := networking.k8s.io/v1 -}}
+  {{- $apiV1 = true -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+  {{- $apiVersion := networking.k8s.io/v1beta1 -}}
+{{- else -}}
+  {{- $apiVersion := extensions/v1beta1 -}}
+{{- end }}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}
@@ -38,7 +47,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            {{- if $apiV1 }}
             pathType: {{ .pathType }}
             backend:
               service:
@@ -54,7 +63,7 @@ spec:
     {{- end }}
 {{- if $ingress.console.enabled }}
 ---
-apiVersion: {{ include "keycloak.ingressAPIVersion" . }}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "keycloak.fullname" . }}-console
@@ -92,7 +101,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            {{- if $apiV1 }}
             pathType: {{ .pathType }}
             backend:
               service:

--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 5.0.1
+version: 5.0.2
 type: application
 keywords:
   - mailhog

--- a/charts/mailhog/templates/_helpers.tpl
+++ b/charts/mailhog/templates/_helpers.tpl
@@ -81,14 +81,3 @@ Create the name for the outgoing-smtp secret.
         {{- template "mailhog.fullname" . -}}-outgoing-smtp
     {{- end -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "mailhog.ingressAPIVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -1,6 +1,15 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mailhog.fullname" . -}}
-apiVersion: {{ include "mailhog.ingressAPIVersion" . }}
+{{- $apiV1 := false -}}
+{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0-0" .Capabilities.KubeVersion.Version) -}}
+  {{- $apiVersion := networking.k8s.io/v1 -}}
+  {{- $apiV1 = true -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+  {{- $apiVersion := networking.k8s.io/v1beta1 -}}
+{{- else -}}
+  {{- $apiVersion := extensions/v1beta1 -}}
+{{- end }}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -37,7 +46,7 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            {{- if $apiV1 }}
             pathType: {{ .pathType }}
             backend:
               service:

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -1,13 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mailhog.fullname" . -}}
 {{- $apiV1 := false -}}
+{{- $apiVersion := "extensions/v1beta1" -}}
 {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0-0" .Capabilities.KubeVersion.Version) -}}
-  {{- $apiVersion := networking.k8s.io/v1 -}}
+  {{- $apiVersion := "networking.k8s.io/v1" -}}
   {{- $apiV1 = true -}}
 {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-  {{- $apiVersion := networking.k8s.io/v1beta1 -}}
+  {{- $apiVersion := "networking.k8s.io/v1beta1" -}}
 {{- else -}}
-  {{- $apiVersion := extensions/v1beta1 -}}
+  {{- $apiVersion := "extensions/v1beta1" -}}
 {{- end }}
 apiVersion: {{ $apiVersion }}
 kind: Ingress


### PR DESCRIPTION
Fix #496

Alternative to #499 => do not make the api version configurable, but retrieve it correctly.

I changed the logic for both charts => not yet fully tested!