### PR TITLE
[keycloak] Use tpl for ingress hosts in NOTES.txt

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 16.0.1
+version: 16.0.2
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/NOTES.txt
+++ b/charts/keycloak/templates/NOTES.txt
@@ -9,7 +9,7 @@
 Keycloak was installed with an Ingress and an be reached at the following URL(s):
 {{ range $unused, $rule := .Values.ingress.rules }}
   {{- range $rule.paths }}
-  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $rule.host }}{{ .path }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ tpl $rule.host $ }}{{ .path }}
   {{-  end }}
 {{- end }}
 


### PR DESCRIPTION
The Keycloak ingress uses the `tpl` function for `rules.host` and `tls.hosts` which allows us to define a single value for the Keycloak host:

```
myHostValue: "login.example.org"
ingress:
  rules:
    - host: "{{ .Values.myHostValue }}"
  tls:
    - hosts:
        - "{{ .Values.myHostValue }}"
```

Right now, the NOTES.txt does not use the `tpl` function and therefore prints the plain expression:

>  Keycloak was installed with an Ingress and an be reached at the following URL(s):
>
>  - https://{{ .Values.myHostValue }}/

This PR introduces the `tpl` function in NOTES.txt to print the actual host value.