### PR TITLE
[keycloak] put secrets separator at the top of their definition

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 16.0.2
+version: 16.0.3
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/secrets.yaml
+++ b/charts/keycloak/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{- range $nameSuffix, $values := .Values.secrets -}}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -25,5 +26,4 @@ stringData:
   {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 2 }}
   {{- end }}
 {{- end }}
----
 {{- end -}}


### PR DESCRIPTION
Fixes #504 'invalid Yaml document separator' error when there is more than one secret declared in keycloak chart values

Signed-off-by: Hervé Le Meur <hlemeur@cloudbees.com>