### PR TITLE
[keycloak] Add option to skip init containers

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 16.0.3
+version: 16.0.4
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `podSecurityContext` | SecurityContext for the entire Pod. Every container running in the Pod will inherit this SecurityContext. This might be relevant when other components of the environment inject additional containers into running Pods (service meshes are the most prominent example for this) | `{"fsGroup":1000}` |
 | `securityContext` | SecurityContext for the Keycloak container | `{"runAsNonRoot":true,"runAsUser":1000}` |
 | `extraInitContainers` | Additional init containers, e. g. for providing custom themes | `[]` |
+| `skipInitContainers` | Skip all init containers (to avoid issues with service meshes which require sidecar proxies for connectivity) | `false`
 | `extraContainers` | Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy | `[]` |
 | `lifecycleHooks` | Lifecycle hooks for the Keycloak container | `{}` |
 | `terminationGracePeriodSeconds` | Termination grace period in seconds for Keycloak shutdown. Clusters with a large cache might need to extend this to give Infinispan more time to rebalance | `60` |

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -41,6 +41,7 @@ spec:
         {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 8 }}
         {{- end }}
     spec:
+    {{- if not .Values.skipInitContainers }}
       {{- if or .Values.postgresql.enabled .Values.extraInitContainers }}
       initContainers:
         {{- if .Values.postgresql.enabled }}
@@ -67,6 +68,7 @@ spec:
         {{- tpl . $ | nindent 8 }}
         {{- end }}
       {{- end }}
+    {{- end }}
       containers:
         - name: keycloak
           securityContext:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -71,6 +71,12 @@ securityContext:
 # Additional init containers, e. g. for providing custom themes
 extraInitContainers: ""
 
+# When using service meshes which rely on a sidecar, it may be necessary to skip init containers altogether, 
+# since the sidecar doesn't start until the init containers are done, and the sidecar may be required 
+# for network access.
+# For example, Istio in strict mTLS mode prevents the pgchecker init container from ever completing
+skipInitContainers: false
+
 # Additional sidecar containers, e. g. for a database proxy, such as Google's cloudsql-proxy
 extraContainers: ""
 

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -71,8 +71,8 @@ securityContext:
 # Additional init containers, e. g. for providing custom themes
 extraInitContainers: ""
 
-# When using service meshes which rely on a sidecar, it may be necessary to skip init containers altogether, 
-# since the sidecar doesn't start until the init containers are done, and the sidecar may be required 
+# When using service meshes which rely on a sidecar, it may be necessary to skip init containers altogether,
+# since the sidecar doesn't start until the init containers are done, and the sidecar may be required
 # for network access.
 # For example, Istio in strict mTLS mode prevents the pgchecker init container from ever completing
 skipInitContainers: false


### PR DESCRIPTION
Hi guys,

This PR adds a non-default option to skip any initContainers when deploying the keycloak statefulset. 

Why?

Because when using a service mesh whose connectivity relies on a sidecar (like Istio's envoy-proxy), an initContainer which requires network connectivity will never complete.

Cheers!
D