### PR TITLE
[keycloak] fix: correct way of fixing separator lint issue #504

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 16.0.4
+version: 16.0.5
 appVersion: 15.0.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/secrets.yaml
+++ b/charts/keycloak/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{- range $nameSuffix, $values := .Values.secrets }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -25,5 +26,4 @@ stringData:
   {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 2 }}
   {{- end }}
 {{- end }}
----
 {{- end -}}

--- a/charts/keycloak/templates/secrets.yaml
+++ b/charts/keycloak/templates/secrets.yaml
@@ -1,5 +1,4 @@
-{{- range $nameSuffix, $values := .Values.secrets -}}
----
+{{- range $nameSuffix, $values := .Values.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,4 +25,5 @@ stringData:
   {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 2 }}
   {{- end }}
 {{- end }}
+---
 {{- end -}}


### PR DESCRIPTION
My previous PR [#505](https://github.com/codecentric/helm-charts/pull/505) introduced an error as multiple secrets defined in one file weren't separated anymore by '---', so my fix of putting the separator at the top of the secret template wasn't enought.

The correct fix is to remove the trimming on the right side of the range. (Pass the lint too)

Signed-off-by: Hervé Le Meur <hlemeur@cloudbees.com>