### PR TITLE
[mailhog] fix: health check

### DIFF
--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -59,13 +59,15 @@ spec:
               containerPort: 1025
               protocol: TCP
           livenessProbe:
-            tcpSocket:
-              port: tcp-smtp
+            httpGet:
+              path: /
+              port: http
             initialDelaySeconds: 10
             timeoutSeconds: 1
           readinessProbe:
-            tcpSocket:
-              port: tcp-smtp
+            httpGet:
+              path: /
+              port: http
           {{- if .Values.auth.enabled }}
           volumeMounts:
             - name: authdir


### PR DESCRIPTION
Signed-off-by: Adam Szucs-Matyas <szucsitg@gmail.com>

Current health check generates 5 lines of log for every health check as it's only checking for open port. This PR moves the health check to web UI path, which passes with correct HTTP code, but doesn't generate log entries.

```log
[SMTP 10.244.0.1:41584] Starting session
[SMTP 10.244.0.1:41584] [PROTO: INVALID] Started session, switching to ESTABLISH state
[SMTP 10.244.0.1:41584] Sent 44 bytes: '220 mailhog-77bb99c668-j4f2n ESMTP MailHog\r\n'
[SMTP 10.244.0.1:41584] Connection closed by remote host
[SMTP 10.244.0.1:41584] Session ended
```