### PR TITLE
[keycloak] chore: Update Keycloak readme with respect to <10.x upgrade 

### DIFF
--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -741,8 +741,15 @@ The following procedure takes care of this:
 
 * Keycloak is updated to 12.0.4
 
-The upgrade should be seemless.
-No special care has to be taken.
+Note that this might not be a seamless upgrade, because the clustering with older Keycloak versions might not work 
+due to incompatible infinispan versions.
+
+One way to perform the upgrade is to run:
+```
+kubectl delete sts <RELEASE_NAME>-keycloak && helm upgrade --install
+```
+This ensures that all replicas are restarted with the same version.
+Note that all sessions are lost in this case, and users might need to login again.
 
 ### From chart versions < 9.0.0
 


### PR DESCRIPTION
* Cluster upgrade failed during testing of a 3 node cluster from the 9.5.0 chart to 10.3.1, the first upgraded keycloak pod failed to parse some infinispan messages.
* Updated section to include same guidance as other incompatible
  upgrades.
