### PR TITLE
[keycloak] Update minor Keycloak version to 15.1.1

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloak
 version: 16.0.6
-appVersion: 15.0.2
+appVersion: 15.1.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
