### PR TITLE
[keycloak] Major Keycloak Update to version 16.1.1

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloak
 version: 16.1.0
-appVersion: 15.1.1
+appVersion: 16.1.1
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -668,6 +668,12 @@ ingress:
 
 ## Upgrading
 
+### From chart < 16.0.0
+
+* Keycloak is updated to 16.1.1
+
+Please read the additional notes about [Migrating to 16.0.0](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-16-0-0) in the Keycloak documentation.
+
 ### From chart < 15.0.0
 
 * Keycloak is updated to 15.0.2


### PR DESCRIPTION
Fixes #531

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
