### PR TITLE
[keycloak] Fix #522 : allow to deploy ingress without host specified

### DIFF
--- a/charts/keycloak/templates/NOTES.txt
+++ b/charts/keycloak/templates/NOTES.txt
@@ -9,7 +9,11 @@
 Keycloak was installed with an Ingress and an be reached at the following URL(s):
 {{ range $unused, $rule := .Values.ingress.rules }}
   {{- range $rule.paths }}
+  {{- if $rule.host }}
   - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ tpl $rule.host $ }}{{ .path }}
+  {{- else }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://<INGRESS_ADDRESS>{{ .path }}
+  {{-  end }}
   {{-  end }}
 {{- end }}
 

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -43,7 +43,10 @@ spec:
 {{- end }}
   rules:
     {{- range .Values.ingress.rules }}
-    - host: {{ tpl .host $ | quote }}
+    - 
+      {{- if .host }}
+      host: {{ tpl .host $ | quote }}
+      {{- end }}
       http:
         paths:
           {{- range .paths }}
@@ -97,7 +100,10 @@ spec:
 {{- end }}
   rules:
     {{- range .Values.ingress.console.rules }}
-    - host: {{ tpl .host $ | quote }}
+    - 
+      {{- if .host }}
+      host: {{ tpl .host $ | quote }}
+      {{- end }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
Fix for issue #522 : Allow to deploy ingress without host specified 