### PR TITLE
[mailhog] Incorrect YAML syntax when Ingress labels are used

### DIFF
--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -14,9 +14,9 @@ apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
The template has labels above and below the namespace key. When you add ingress labels, which we do for cost attribution purposes, the ingress labels come AFTER the namespace which creates invalid YAML syntax.

![Mailhog Label Fix](https://user-images.githubusercontent.com/1662662/152060799-bb04546b-25fc-4438-a252-8612b673a125.jpg)

Signed-off-by: Ashley Cambrell acambrell@gmail.com
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
