### PR TITLE
[mailhog] Incorrect YAML syntax when Ingress labels are used

### DIFF
--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -14,9 +14,9 @@ apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Signed-off-by: Ashley Cambrell <acambrell@gmail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
