### PR TITLE
[mailhog] fix: auth volume overwritten when outgoingSMTP.enabled

### DIFF
--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -66,17 +66,18 @@ spec:
           readinessProbe:
             tcpSocket:
               port: tcp-smtp
-          {{- if .Values.auth.enabled }}
+          {{ if or .Values.auth.enabled .Values.outgoingSMTP.enabled }}
           volumeMounts:
+            {{- if .Values.auth.enabled }}
             - name: authdir
               mountPath: /authdir
               readOnly: true
-          {{- end }}
-          {{- if .Values.outgoingSMTP.enabled }}
-          volumeMounts:
+            {{- end }}
+            {{- if .Values.outgoingSMTP.enabled }}
             - name: outsmtpdir
               mountPath: /config
               readOnly: true
+            {{- end }}
           {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
@@ -96,15 +97,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.auth.enabled }}
+      {{- if or .Values.auth.enabled .Values.outgoingSMTP.enabled }}
       volumes:
+        {{- if .Values.auth.enabled }}
         - name: authdir
           secret:
             secretName: {{ template "mailhog.authFileSecret" . }}
-      {{- end }}
-      {{- if .Values.outgoingSMTP.enabled }}
-      volumes:
+        {{- end }}
+        {{- if .Values.outgoingSMTP.enabled }}
         - name: outsmtpdir
           secret:
             secretName: {{ template "mailhog.outgoingSMTPSecret" . }}
+        {{- end }}
       {{- end }}


### PR DESCRIPTION
now:
when outgoingSMTP.enabled and auth.enabled the SMTP volume write to the root volumes key

fix:
make the volume key either or and add to the array of volume to support either or both

log:
```
➜ ~ k logs -f -n $n $p
2022/02/02 05:32:58 Using in-memory storage
[HTTP] Error reading auth-file: open /authdir/auth.txt: no such file or directory
```


<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
