### PR TITLE
Keycloak change

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,9 @@
+Repo:
+ - '*'
+ - '.github/**'
+
+Keycloak:
+ - charts/keycloak/**
+
+Mailhog:
+  - charts/mailhog/**

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -1,7 +1,7 @@
 # Keycloak
 
 [Keycloak](http://www.keycloak.org/) is an open source identity and access management for modern applications and services.
-
+foo
 ## TL;DR;
 
 ```console


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
