### PR TITLE
Use policy/v1 api for PDB in K8s ver 1.21+

### DIFF
--- a/charts/keycloak/templates/poddisruptionbudget.yaml
+++ b/charts/keycloak/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget -}}
+{{- if semverCompare ">=1.21.0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "keycloak.fullname" . }}


### PR DESCRIPTION
Policy/v1beta1 is deprecated in Kubernetes since version 1.21.

The PR will adapt PodDisruptionBudget API version in Keycloak based on Kubernetes version.