### PR TITLE
Introduced priorityClassName

### DIFF
--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `podLabels` | Extra labels to add to pod | `{}`
 `resources` | Pod resource requests and limits | `{}`
 `tolerations` | Node taints to tolerate | `[]`
+`priorityClassName` | Name of the existing priority class to be used by Mailhog pod, priority class needs to be created beforehand | `""`
 `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
 `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""` |
 `serviceAccount.imagePullSecrets` | Image pull secrets that are attached to the ServiceAccount | `[]` |

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -108,3 +108,6 @@ spec:
           secret:
             secretName: {{ template "mailhog.outgoingSMTPSecret" . }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -117,3 +117,5 @@ affinity: {}
 nodeSelector: {}
 
 tolerations: []
+
+priorityClassName:


### PR DESCRIPTION
Added possibility to set priorityClassName.

Signed-off-by: Błażej Frydlewicz <b.frydlewicz@piwik.pro>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
