### PR TITLE
fixes 556 by replace attribute name with number for ingress port spec

### DIFF
--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -43,7 +43,7 @@ spec:
 {{- end }}
   rules:
     {{- range .Values.ingress.rules }}
-    - 
+    -
       {{- if .host }}
       host: {{ tpl .host $ | quote }}
       {{- end }}
@@ -57,7 +57,7 @@ spec:
               service:
                 name: {{ include "keycloak.fullname" $ }}-http
                 port:
-                  name: {{ $ingress.servicePort }}
+                  number: {{ $ingress.servicePort }}
             {{- else }}
             backend:
               serviceName: {{ include "keycloak.fullname" $ }}-http
@@ -100,7 +100,7 @@ spec:
 {{- end }}
   rules:
     {{- range .Values.ingress.console.rules }}
-    - 
+    -
       {{- if .host }}
       host: {{ tpl .host $ | quote }}
       {{- end }}


### PR DESCRIPTION
fixes #556 by replacing attribute `name` with `number` in ingress port spec
