### PR TITLE
[keycloakx] Major Keycloak.X Update to version 17.0.1

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloakx
 version: 1.0.0
 appVersion: 17.0.1
-description: Keycloak.X - Open Source Identity and Access Management For Modern Applications and Services
+description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso
   - idm


### PR DESCRIPTION
See 31f44ca

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
