### PR TITLE
Adapt release workflow to support keycloakx chart

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -27,6 +27,11 @@ jobs:
       with:
         chart: keycloak
 
+    - name: Bump Keycloak.X
+      uses: ./.github/actions/bumpVersionAction
+      with:
+        chart: keycloakx
+
     - name: Bump Mailhog
       uses: ./.github/actions/bumpVersionAction
       with:


### PR DESCRIPTION
Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
