### PR TITLE
Mailhog: Quote namespace

### DIFF
--- a/charts/mailhog/templates/auth-secret.yaml
+++ b/charts/mailhog/templates/auth-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
   name: {{ template "mailhog.authFileSecret" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
   {{ .Values.auth.fileName }}: {{ .Values.auth.fileContents | b64enc }}

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "mailhog.fullname" . }}
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   selector:
     matchLabels:

--- a/charts/mailhog/templates/ingress.yaml
+++ b/charts/mailhog/templates/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
   {{- with .Values.ingress.labels }}

--- a/charts/mailhog/templates/service.yaml
+++ b/charts/mailhog/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   type: "{{ .Values.service.type }}"
   {{- with .Values.service.clusterIP }}

--- a/charts/mailhog/templates/serviceaccount.yaml
+++ b/charts/mailhog/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "mailhog.serviceAccountName" . }}
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 imagePullSecrets:
   {{- toYaml .Values.serviceAccount.imagePullSecrets | nindent 4 }}
 {{- end }}

--- a/charts/mailhog/templates/smtp-secret.yaml
+++ b/charts/mailhog/templates/smtp-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "mailhog.labels" . | nindent 4 }}
   name: {{ template "mailhog.outgoingSMTPSecret" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
   {{ .Values.outgoingSMTP.fileName }}: {{ .Values.outgoingSMTP.fileContents | toJson | b64enc }}


### PR DESCRIPTION
Signed-off-by: Dennis Urban <mail@dpunkturban.io>

Hi,

i quoted all namespaces in the mailhog chart, so it can be used in namespaces with numeric names. Without quoting, i get the following error because the numeric namespace is interpreted as number and not string:

```
❯ helm install mailhog .
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: unable to decode "": json: cannot unmarshal number into Go struct field ObjectMeta.metadata.namespace of type string
```

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
