### PR TITLE
[keycloakx] feature: Add support for kube_ping clustering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv
 charts/**/charts
 .cr-*
 /ct_*
+*.jar

--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -7,8 +7,31 @@ Note that this chart is the logical successor of the Wildfly based [codecentric/
 ## TL;DR;
 
 ```console
-$ helm install keycloak codecentric/keycloakx
+$ cat << EOF > values.yaml
+command:
+  - "/opt/keycloak/bin/kc.sh"
+  - "start"
+  - "--auto-build"
+  - "--http-enabled=true"
+  - "--http-port=8080"
+  - "--hostname-strict=false"
+  - "--hostname-strict-https=false"
+extraEnv: |
+  - name: KEYCLOAK_ADMIN
+    value: admin
+  - name: KEYCLOAK_ADMIN_PASSWORD
+    value: admin
+  - name: JAVA_OPTS_APPEND
+    value: >-
+      -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
+EOF
+
+$ helm install keycloak codecentric/keycloakx --values ./values.yaml
 ```
+Note that the default configuration is not suitable for production since it uses a h2 file database by default.
+It is strongly recommended to use a dedicated database with Keycloak.
+
+For more examples see the [examples](./examples) folder.
 
 ## Introduction
 
@@ -50,6 +73,7 @@ The following table lists the configurable parameters of the Keycloak-X chart an
 | `podManagementPolicy`                        | Pod management policy. One of `Parallel` or `OrderedReady`                                                                                                                                                                                                                        | `Parallel`                                                                                                                            |
 | `restartPolicy`                              | Pod restart policy. One of `Always`, `OnFailure`, or `Never`                                                                                                                                                                                                                      | `Always`                                                                                                                              |
 | `serviceAccount.create`                      | Specifies whether a ServiceAccount should be created                                                                                                                                                                                                                              | `true`                                                                                                                                |
+| `serviceAccount.allowReadPods`               | Specifies whether the ServiceAccount can get or list pods                                                                                                                                                                                                                         | `false`                                                                                                                               |
 | `serviceAccount.name`                        | The name of the service account to use. If not set and create is true, a name is generated using the fullname template                                                                                                                                                            | `""`                                                                                                                                  |
 | `serviceAccount.annotations`                 | Additional annotations for the ServiceAccount                                                                                                                                                                                                                                     | `{}`                                                                                                                                  |
 | `serviceAccount.labels`                      | Additional labels for the ServiceAccount                                                                                                                                                                                                                                          | `{}`                                                                                                                                  |
@@ -120,9 +144,9 @@ The following table lists the configurable parameters of the Keycloak-X chart an
 | `ingress.console.rules[0].paths[0].pathType` | Path Type for the Ingress rule for the console                                                                                                                                                                                                                                    | `Prefix`                                                                                                                              |
 | `ingress.console.annotations`                | Ingress annotations for the console                                                                                                                                                                                                                                               | `{}`                                                                                                                                  |
 | `ingress.console.ingressClassName`           | The name of the Ingress Class associated with the console ingress                                                                                                                                                                                                                 | `""`                                                                                                                                  |
-| `ingress.console.tls` | TLS configuration | see below |
-| `ingress.console.tls[0].hosts` | List of TLS hosts | `[keycloak.example.com]` |
-| `ingress.console.tls[0].secretName` | Name of the TLS secret | `""` |
+| `ingress.console.tls` | TLS configuration                                                                                                                                                                                                                                                                 | see below                                                                                                                             |
+| `ingress.console.tls[0].hosts` | List of TLS hosts                                                                                                                                                                                                                                                                 | `[keycloak.example.com]`                                                                                                              |
+| `ingress.console.tls[0].secretName` | Name of the TLS secret                                                                                                                                                                                                                                                            | `""`                                                                                                                                  |
 | `networkPolicy.enabled`                      | If true, the ingress network policy is deployed                                                                                                                                                                                                                                   | `false`
 | `networkPolicy.extraFrom`                    | Allows to define allowed external traffic (see Kubernetes doc for network policy `from` format)                                                                                                                                                                                   | `[]`
 | `route.enabled`                              | If `true`, an OpenShift Route is created                                                                                                                                                                                                                                          | `false`                                                                                                                               |

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,0 +1,9 @@
+FROM quay.io/keycloak/keycloak:17.0.1
+
+ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
+
+# Downlaod JGroups KubePing extension
+RUN curl -s -L -o /opt/keycloak/providers/jgroups-kubernetes-$JGROUPS_KUBERNETES_VERSION.jar https://search.maven.org/remotecontent?filepath=org/jgroups/kubernetes/jgroups-kubernetes/$JGROUPS_KUBERNETES_VERSION/jgroups-kubernetes-$JGROUPS_KUBERNETES_VERSION.jar
+
+# Add custom kubeping configuration file
+COPY cache-ispn-kubeping.xml /opt/keycloak/conf

--- a/charts/keycloakx/examples/postgresql-kubeping/cache-ispn-kubeping.xml
+++ b/charts/keycloakx/examples/postgresql-kubeping/cache-ispn-kubeping.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:13.0 http://www.infinispan.org/schemas/infinispan-config-13.0.xsd"
+        xmlns="urn:infinispan:config:13.0">
+
+    <!-- https://github.com/infinispan/infinispan.github.io/tree/develop/schemas -->
+
+    <!-- custom stack goes into the jgroups element -->
+    <!-- see https://infinispan.org/blog/2019/03/05/enhanced-jgroups-configuration/ -->
+    <!-- see http://jgroups.org/manual4/index.html#CommonProps -->
+    <jgroups xmlns="http://jgroups.org/schema/jgroups-4.2.xsd">
+        <stack name="tcp-k8s" extends="tcp">
+            <org.jgroups.protocols.kubernetes.KUBE_PING
+                    port_range="1"
+                    namespace="${kubeping_namespace}"
+                    labels="${kubeping_label}"
+                    stack.position="MPING"
+                    stack.combine="REPLACE"/>
+        </stack>
+    </jgroups>
+
+    <cache-container name="keycloak">
+        <!-- custom stack must be referenced by name in the stack attribute of the transport element -->
+        <!-- note, that this should be keept aligned with: https://github.com/keycloak/keycloak/blob/main/quarkus/runtime/src/main/resources/cache-ispn.xml -->
+        <transport lock-timeout="60000" stack="tcp-k8s"/>
+        <local-cache name="realms">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <local-cache name="users">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <distributed-cache name="sessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="authenticationSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="offlineSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="clientSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="offlineClientSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="loginFailures" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <local-cache name="authorization">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <replicated-cache name="work">
+            <expiration lifespan="-1"/>
+        </replicated-cache>
+        <local-cache name="keys">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="3600000"/>
+            <memory max-count="1000"/>
+        </local-cache>
+        <distributed-cache name="actionTokens" owners="2">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+            <memory max-count="-1"/>
+        </distributed-cache>
+    </cache-container>
+</infinispan>

--- a/charts/keycloakx/examples/postgresql-kubeping/keycloak-db-values.yaml
+++ b/charts/keycloakx/examples/postgresql-kubeping/keycloak-db-values.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/bitnami/charts/tree/master/bitnami/postgresql
+global:
+  postgresql:
+    auth:
+      username: dbusername
+      password: dbpassword
+      database: keycloak

--- a/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
@@ -1,0 +1,71 @@
+# This is an example configuration, for production grade configuration see the Keycloak documentation.
+# See https://www.keycloak.org/server/configuration
+# See https://www.keycloak.org/server/all-config
+command:
+  - "/opt/keycloak/bin/kc.sh"
+  - "--verbose"
+  - "start"
+  - "--auto-build"
+  - "--http-enabled=true"
+  - "--http-port=8080"
+  - "--hostname-strict=false"
+  - "--hostname-strict-https=false"
+  - "--spi-events-listener-jboss-logging-success-level=info"
+  - "--spi-events-listener-jboss-logging-error-level=warn"
+
+# Disable default cache configuration
+cache:
+  stack: custom
+
+image:
+  # The custom image repository
+  repository: thomasdarimont/keycloakx-kubeping
+  # Overrides the Keycloak image tag whose default is the chart appVersion
+  tag: latest
+
+extraEnv: |
+  - name: KC_CACHE_CONFIG_FILE
+    value: cache-ispn-kubeping.xml
+  - name: KEYCLOAK_ADMIN
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "keycloak.fullname" . }}-admin-creds
+        key: user
+  - name: KEYCLOAK_ADMIN_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "keycloak.fullname" . }}-admin-creds
+        key: password
+  - name: JAVA_OPTS_APPEND
+    value: >-
+      -XX:+UseContainerSupport
+      -XX:MaxRAMPercentage=50.0
+      -Djava.awt.headless=true
+      -Dkubeping_namespace={{ .Release.Namespace }}
+      -Dkubeping_label="keycloak-cluster=default"
+
+serviceAccount:
+  create: true
+  allowReadPods: true
+
+podLabels:
+  keycloak-cluster: default
+
+dbchecker:
+  enabled: true
+
+database:
+  vendor: postgres
+  hostname: keycloak-db-postgresql
+  port: 5432
+  username: dbusername
+  password: dbpassword
+  database: keycloak
+
+secrets:
+  admin-creds:
+    annotations:
+      my-test-annotation: Test secret for {{ include "keycloak.fullname" . }}
+    stringData:
+      user: admin
+      password: secret

--- a/charts/keycloakx/examples/postgresql-kubeping/readme.md
+++ b/charts/keycloakx/examples/postgresql-kubeping/readme.md
@@ -1,0 +1,79 @@
+# Keycloak.X with KUBE_PING
+
+This example shows how to use KUBE_PING JGroup cluster discovery with Keycloak.X.
+
+Since Keycloak.X currently (17.0.1) does not support jgroups KUBE_PING out of the box,
+we need to download the library and copy it into a custom docker image.
+
+Note that we use some customizations in the `keycloak-server-values.yaml` file:
+- Set environment variable `KC_CACHE_CONFIG_FILE=cache-ispn-kubeping.xml` to our custom cache config file
+- Disable automatic cache configuration via `cache.stack=custom`
+- Configure `kubeping_namespace` and `kubeping_label` system properties via `JAVA_OPTS_APPEND`
+- Configure serviceAccount.create=true and serviceAccount.allowReadPods=true to allow kube_ping to enlist keycloak pods
+
+# Setup
+
+## Add repository
+```
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add codecentric https://codecentric.github.io/helm-charts
+```
+
+## Update helm repos
+```
+helm repo update
+```
+
+## Build custom Docker Image
+
+This custom image automatically downloads the jgroups-kubernetes library.
+```
+docker build -t thomasdarimont/keycloakx-kubeping .
+```
+
+We need to make the custom docker image available in the Kubernetes cluster. This is up to your k8s environment.
+With [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) you can use `kind load docker-image thomasdarimont/keycloakx-kubeping:latest`.
+
+## Deploy a PostgreSQL database
+```
+helm install keycloak-db bitnami/postgresql --values ./keycloak-db-values.yaml
+```
+
+# Deploy Keycloak
+
+```
+helm install keycloak codecentric/keycloakx --values ./keycloak-server-values.yaml
+```
+
+If everything worked you should now see log entries like this:
+```
+...
+keycloak 2022-04-09 15:14:55,997 INFO  [org.jgroups.protocols.kubernetes.KUBE_PING] (keycloak-cache-init) namespace default set; clustering enabled
+...
+```
+
+On a new Keycloak pod you should see the following log entries:
+```
+...
+15:16:20,184 INFO  [org.jgroups.protocols.kubernetes.KUBE_PING] (keycloak-cache-init) namespace default set; clustering enabled
+15:16:20,395 INFO  [org.infinispan.CLUSTER] (keycloak-cache-init) ISPN000094: Received new cluster view for channel ISPN: [keycloak-keycloakx-0-34953|1] (2) [keycloak-keycloakx-0-34953, keycloak-keycloakx-1-34016]
+15:16:20,399 INFO  [org.infinispan.CLUSTER] (keycloak-cache-init) ISPN000079: Channel `ISPN` local address is `keycloak-keycloakx-1-34016`, physical addresses are `[10.244.0.22:7800]`
+...
+```
+
+# Access Keycloak
+Once Keycloak is running, forward the HTTP service port to 8080.
+
+```
+kubectl port-forward service/keycloak-keycloakx-http 8080:80
+```
+
+You can then access the Keycloak Admin-Console via `http://localhost:8080/auth` with
+username: `admin` and password: `secret`.
+
+# Remove Keycloak
+
+```
+helm uninstall keycloak
+helm uninstall keycloak-db
+```

--- a/charts/keycloakx/examples/postgresql/readme.md
+++ b/charts/keycloakx/examples/postgresql/readme.md
@@ -1,4 +1,6 @@
-# Example for using Keycloak.X with PostgreSQL
+# Keycloak.X with PostgreSQL
+
+This example shows how to configure Keycloak.X to use a PostgreSQL database.
 
 # Setup
 
@@ -37,4 +39,5 @@ username: `admin` and password: `secret`.
 
 ```
 helm uninstall keycloak
+helm uninstall keycloak-db
 ```

--- a/charts/keycloakx/examples/readme.md
+++ b/charts/keycloakx/examples/readme.md
@@ -1,5 +1,10 @@
-# Examples for using the KeycloakX Helm Chart
+# KeycloakX Helm Chart Examples
+
+Various examples for using the helm chart for custom deployments.
 
 ## Keycloak.X with PostgreSQL
 
 - See [using Keycloak.X with PostgreSQL](./postgresql/readme.md).
+
+## Keycloak.X with KUBE_PING
+- See [using Keycloak.X with KUBE_PING](./postgresql-kubeping/readme.md).

--- a/charts/keycloakx/templates/serviceaccount.yaml
+++ b/charts/keycloakx/templates/serviceaccount.yaml
@@ -16,4 +16,30 @@ metadata:
     {{- end }}
 imagePullSecrets:
   {{- toYaml .Values.serviceAccount.imagePullSecrets | nindent 4 }}
+
+---
+
+  {{- if .Values.serviceAccount.allowReadPods -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jgroups-kubeping-pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jgroups-kubeping-api-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jgroups-kubeping-pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "keycloak.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+  {{- end }}
 {{- end }}

--- a/charts/keycloakx/values.schema.json
+++ b/charts/keycloakx/values.schema.json
@@ -397,6 +397,9 @@
           "create": {
             "type": "boolean"
           },
+          "allowReadPods": {
+            "type": "boolean"
+          },
           "imagePullSecrets": {
             "$ref": "#/definitions/imagePullSecrets"
           },

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -37,6 +37,8 @@ restartPolicy: Always
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Specifies whether the ServiceAccount can get and list pods
+  allowReadPods: false
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""


### PR DESCRIPTION
- Added support for allowing the Keycloak service-account to read
  pod information required for kube_ping
- Added an example for using jgroups with kube_ping

Fixes #568

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
