### PR TITLE
Fixes the release action after git patched CVE-2022-24765

### DIFF
--- a/.github/actions/bumpVersionAction/Dockerfile
+++ b/.github/actions/bumpVersionAction/Dockerfile
@@ -1,8 +1,11 @@
 # Container image that runs your code
 FROM python:alpine
 
+WORKDIR /github/workspace
+
 RUN pip install bump2version && apk add git
 
 COPY bump-version.py /bump-version.py
 
-ENTRYPOINT ["python" ,"/bump-version.py"]
+# The git add safe.directory $(pwd) is needed because since CVE-2022-24765 git checks the owernership of the processed repos
+CMD sh -c 'git config --global --add safe.directory $(pwd) && exec python /bump-version.py'

--- a/.github/actions/bumpVersionAction/action.yml
+++ b/.github/actions/bumpVersionAction/action.yml
@@ -11,5 +11,5 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.chart }}
+  env:
+    CHART_NAME: ${{ inputs.chart }}

--- a/.github/actions/bumpVersionAction/bump-version.py
+++ b/.github/actions/bumpVersionAction/bump-version.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from enum import Enum
@@ -29,13 +30,14 @@ def handle_subprocess_error(subprocess_result, error_message):
 
 
 if __name__ == "__main__":
-    chart_name = sys.argv[1]
+    chart_name = os.getenv("CHART_NAME")
     print(f"Bumping chart version for: {chart_name}")
 
     from_commit_hash_process = subprocess.run(f"git rev-parse ':/^Bump {chart_name} chart version:'",
                                               shell=True,
                                               capture_output=True)
     if from_commit_hash_process.returncode != 0:
+        print(str(from_commit_hash_process.stderr, 'UTF-8'))
         print("Did not find the last bump commit. Assuming PATCH update now")
         upgrade_type = UpgradeType.PATCH
     else:


### PR DESCRIPTION
Git now checks for correct ownership of repositories it processes and
inside the docker container the permissions did not match. The fix tells
 git to assume the current directory as safe

Signed-off-by: Mirco Hacker <mirco.hacker@codecentric.de>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
