### PR TITLE
fix ingress apiVersion with KubeVersion

### DIFF
--- a/charts/keycloakx/templates/ingress.yaml
+++ b/charts/keycloakx/templates/ingress.yaml
@@ -1,6 +1,15 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
-{{- $apiVersion := "networking.k8s.io/v1" -}}
+{{- $apiV1 := false -}}
+{{- $apiVersion := "extensions/v1beta1" -}}
+{{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= v1.19.0-0" .Capabilities.KubeVersion.Version) -}}
+  {{- $apiVersion = "networking.k8s.io/v1" -}}
+  {{- $apiV1 = true -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+  {{- $apiVersion = "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+  {{- $apiVersion = "extensions/v1beta1" -}}
+{{- end }}
 apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
@@ -39,12 +48,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ tpl .path $ | quote }}
+            {{- if $apiV1 }}
             pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ include "keycloak.fullname" $ }}-http
                 port:
                   name: {{ $ingress.servicePort }}
+            {{- else }}
+            backend:
+              serviceName: {{ include "keycloak.fullname" $ }}-http
+              servicePort: {{ $ingress.servicePort }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- if $ingress.console.enabled }}
@@ -98,12 +113,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ tpl .path $ | quote }}
+            {{- if $apiV1 }}
             pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ include "keycloak.fullname" $ }}-http
                 port:
                   name: {{ $ingress.servicePort }}
+            {{- else }}
+            backend:
+              serviceName: {{ include "keycloak.fullname" $ }}-http
+              servicePort: {{ $ingress.servicePort }}
+            {{- end }}
           {{- end }}
     {{- end }}
 {{- end -}}


### PR DESCRIPTION
Fix ingress api version for Kubernetes version below  1.19+
According to the documentation of Kubernetes 
```
networking.k8s.io/v1beta1 = 1.14 to 1.18
networking.k8s.io/v1 = 1.19+
```

Similar with https://github.com/codecentric/helm-charts/pull/501
