### PR TITLE
fix ClusterRole and ClusterRoleBinding names. Need if multiple namesp…

### DIFF
--- a/charts/keycloakx/templates/serviceaccount.yaml
+++ b/charts/keycloakx/templates/serviceaccount.yaml
@@ -23,7 +23,7 @@ imagePullSecrets:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jgroups-kubeping-pod-reader
+  name: jgroups-kubeping-pod-reader-{{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -32,11 +32,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: jgroups-kubeping-api-access
+  name: jgroups-kubeping-api-access-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: jgroups-kubeping-pod-reader
+  name: jgroups-kubeping-pod-reader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "keycloak.serviceAccountName" . }}


### PR DESCRIPTION
If you have multiple namespaces, an error occurs:

`Error: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole \"jgroups-kubeping-pod-reader\" in namespace \"\" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key \"meta.helm.sh/release-namespace\" must equal \"ns-temp-1\": current value is \"ns-temp-2\"`