### PR TITLE
feat(values): Add extraDeploy attribute to values

### DIFF
--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -207,6 +207,7 @@ The following table lists the configurable parameters of the Keycloak-X chart an
 | `test.podSecurityContext`                    | SecurityContext for the entire test Pod                                                                                                                                                                                                                                           | `{"fsGroup":1000}`                                                                                                                    |
 | `test.securityContext`                       | SecurityContext for the test container                                                                                                                                                                                                                                            | `{"runAsNonRoot":true,"runAsUser":1000}`                                                                                              |
 | `test.deletionPolicy` | `helm.sh/hook-delete-policy` for the test Pod | `before-hook-creation` |
+| `ExtraDeploy` | Array of extra objects to deploy with the release | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
@@ -553,6 +554,11 @@ annotations:
         return 403;
     }
 ```
+
+### Deploy extra resources
+
+There are cases where you may want to deploy extra objects, such a ConfigMap containing your app's configuration or some extra deployment with a micro service used by your app. For covering this case, the chart allows adding the full specification of other objects using the extraDeploy parameter.
+
 
 ## Why StatefulSet?
 

--- a/charts/keycloakx/templates/_tplvalues.tpl
+++ b/charts/keycloakx/templates/_tplvalues.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/keycloakx/values.schema.json
+++ b/charts/keycloakx/values.schema.json
@@ -476,6 +476,9 @@
       },
       "tolerations": {
         "type": "array"
+      },
+      "extraDeploy": {
+        "type": "array"
       }
     }
   }

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -504,3 +504,8 @@ test:
     runAsNonRoot: true
   # See https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies
   deletionPolicy: before-hook-creation
+
+
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []


### PR DESCRIPTION
Allow to deploy out-of-the-box kubernetes manifests.

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
