### PR TITLE
[keycloakx] Major version upgrade to Keycloak 18.0.0 (#591)

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
 version: 1.3.2
-appVersion: 17.0.1
+appVersion: 18.0.0
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -172,6 +172,7 @@ The following table lists the configurable parameters of the Keycloak-X chart an
 | `proxy.mode`                                 | The configured proxy mode                                                                                                                                                                                                                                                         | `edge`                                                                                                                                |
 | `http.relativePath`                          | The relative http path (context-path)                                                                                                                                                                                                                                             | `/auth`                                                                                                                               |
 | `metrics.enabled`                            | If `true` then the metrics endpoint is exposed                                                                                                                                                                                                                                    | `true`                                                                                                                                |
+| `health.enabled`                            | If `true` then the health endpoint is exposed                                                                                                                                                                                                                                    | `true`                                                                                                                                |
 | `serviceMonitor.enabled`                     | If `true`, a ServiceMonitor resource for the prometheus-operator is created                                                                                                                                                                                                       | `false`                                                                                                                               |
 | `serviceMonitor.namespace`                   | Optionally sets a target namespace in which to deploy the ServiceMonitor resource                                                                                                                                                                                                 | `""`                                                                                                                                  |
 | `serviceMonitor.namespaceSelector`           | Optionally sets a namespace selector for the ServiceMonitor                                                                                                                                                                                                                       | `{}`                                                                                                                                  |
@@ -571,3 +572,13 @@ ingress:
 ## Upgrading
 
 Notes for upgrading from previous Keycloak chart versions.
+
+### From chart < 18.0.0
+
+* Keycloak is updated to 18.0.0
+* Added new `health.enabled` option.
+
+Keycloak 18.0.0 allows to enable the health endpoint independently of the metrics endpoint via the `health-enabled` setting. 
+We reflect that via the new config option `health.enabled`.
+
+Please read the additional notes about [Migrating to 18.0.0](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-18-0-0) in the Keycloak documentation.

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:17.0.1
+FROM quay.io/keycloak/keycloak:18.0.0
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/examples/postgresql-kubeping/readme.md
+++ b/charts/keycloakx/examples/postgresql-kubeping/readme.md
@@ -2,7 +2,7 @@
 
 This example shows how to use KUBE_PING JGroup cluster discovery with Keycloak.X.
 
-Since Keycloak.X currently (17.0.1) does not support jgroups KUBE_PING out of the box,
+Since Keycloak.X (17.0.x, 18.0.x) does not support jgroups KUBE_PING out of the box,
 we need to download the library and copy it into a custom docker image.
 
 Note that we use some customizations in the `keycloak-server-values.yaml` file:

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -126,6 +126,10 @@ spec:
             - name: KC_METRICS_ENABLED
               value: "true"
             {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- tpl . $ | nindent 12 }}
             {{- end }}

--- a/charts/keycloakx/values.schema.json
+++ b/charts/keycloakx/values.schema.json
@@ -250,6 +250,14 @@
           }
         }
       },
+      "health": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
       "database": {
         "type": "object",
         "properties": {

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "17.0.1"
+  tag: "18.0.0"
   # The Keycloak image pull policy
   pullPolicy: IfNotPresent
 
@@ -381,6 +381,9 @@ proxy:
   mode: edge
 
 metrics:
+  enabled: true
+
+health:
   enabled: true
 
 http:


### PR DESCRIPTION
Closes #591

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
