### PR TITLE
[keycloak] Major version upgrade of legacy keycloak to 18.0.0 (#593)

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloak
 version: 18.1.1
-appVersion: 17.0.1-legacy
+appVersion: 18.0.0-legacy
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -671,9 +671,15 @@ ingress:
 
 ## Upgrading
 
+### From chart < 18.0.0
+
+* Keycloak is updated to 18.0.0-legacy
+
+Please read the additional notes about [Migrating to 18.0.0](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-18-0-0) in the Keycloak documentation.
+
 ### From chart < 17.0.1
 
-* Keycloak is updated to 17.0.1
+* Keycloak is updated to 17.0.1-legacy
 * Use image from quay.io/keycloak/keycloak
 
 Note that we now need to add the `-legacy` suffix for the `Keycloak Legacy` image for the Wildfly based Keycloak as documented in [this Keycloak Blog Post](https://www.keycloak.org/2022/02/keycloak-1700-released#_migrating_from_the_preview_quarkus_distribution),


### PR DESCRIPTION
Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
