### PR TITLE
doc (keycloakx): Add example with ingress (#599)

### DIFF
--- a/charts/keycloakx/examples/postgresql-ingress/keycloak-db-values.yaml
+++ b/charts/keycloakx/examples/postgresql-ingress/keycloak-db-values.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/bitnami/charts/tree/master/bitnami/postgresql
+global:
+  postgresql:
+    auth:
+      username: dbusername
+      password: dbpassword
+      database: keycloak

--- a/charts/keycloakx/examples/postgresql-ingress/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql-ingress/keycloak-server-values.yaml
@@ -1,0 +1,78 @@
+# This is an example configuration, for production grade configuration see the Keycloak documentation.
+# See https://www.keycloak.org/server/configuration
+# See https://www.keycloak.org/server/all-config
+command:
+  - "/opt/keycloak/bin/kc.sh"
+  - "--verbose"
+  - "start"
+  - "--auto-build"
+  - "--http-enabled=true"
+  - "--http-port=8080"
+  - "--hostname-strict=false"
+  - "--hostname-strict-https=false"
+  - "--spi-events-listener-jboss-logging-success-level=info"
+  - "--spi-events-listener-jboss-logging-error-level=warn"
+  - "--proxy=edge"
+
+# Configure ingress
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/affinity: cookie
+  rules:
+    - host: id.acme.test
+      paths:
+        - path: /auth
+          pathType: Prefix
+  tls:
+    - hosts: 
+      - id.acme.test
+      paths:
+        - path: /auth
+          pathType: Prefix
+  console:
+    enabled: true
+    tls:
+      - hosts: 
+        - id.acme.test
+        paths:
+          - path: /auth/admin
+            pathType: Prefix
+
+extraEnv: |
+  - name: KEYCLOAK_ADMIN
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "keycloak.fullname" . }}-admin-creds
+        key: user
+  - name: KEYCLOAK_ADMIN_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "keycloak.fullname" . }}-admin-creds
+        key: password
+  - name: JAVA_OPTS_APPEND
+    value: >-
+      -XX:+UseContainerSupport
+      -XX:MaxRAMPercentage=50.0
+      -Djava.awt.headless=true
+      -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
+
+dbchecker:
+  enabled: true
+
+database:
+  vendor: postgres
+  hostname: keycloak-db-postgresql
+  port: 5432
+  username: dbusername
+  password: dbpassword
+  database: keycloak
+
+secrets:
+  admin-creds:
+    annotations:
+      my-test-annotation: Test secret for {{ include "keycloak.fullname" . }}
+    stringData:
+      user: admin
+      password: secret

--- a/charts/keycloakx/examples/postgresql-ingress/kind.md
+++ b/charts/keycloakx/examples/postgresql-ingress/kind.md
@@ -1,0 +1,37 @@
+Cluster setup with kind
+----
+
+This example creates a local Kubernetes cluster running on the local docker host with [Kind](https://kind.sigs.k8s.io/).
+
+The following steps are described in more detail in the [Kind documentation](https://kind.sigs.k8s.io/docs/user/ingress/).
+
+# Create kind cluster
+
+```
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+```
+
+# Deploy Nginx Controller
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+```
+
+Once the Nginx ingress controller is running we can go on and deploy the Keycloak helm chart.

--- a/charts/keycloakx/examples/postgresql-ingress/readme.md
+++ b/charts/keycloakx/examples/postgresql-ingress/readme.md
@@ -1,0 +1,54 @@
+# Keycloak.X with PostgreSQL and NGinx Ingress Controller
+
+This example shows how to configure Keycloak.X to use a PostgreSQL database.
+
+# Setup
+
+## Setup Keycloak cluster
+If you already have a running Keycloak cluster with an Ingress controller configured you can skip this section.
+
+If you want to try this example with a locally running Keycloak cluster, checkout the [Kind Kubernetes cluster example](./kind.md).
+
+## Add repository
+```
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add codecentric https://codecentric.github.io/helm-charts
+```
+
+## Update helm repos
+```
+helm repo update
+```
+
+## Deploy Ingress Controller
+
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+```
+
+## Deploy a PostgreSQL database
+```
+helm install keycloak-db bitnami/postgresql --values ./keycloak-db-values.yaml
+```
+
+# Deploy Keycloak
+```
+helm install keycloak codecentric/keycloakx --values ./keycloak-server-values.yaml
+```
+
+# Access Keycloak
+
+Once Keycloak is running, we should be able to access Keycloak with the configured domain, 
+e.g.: https://id.acme.test/auth.
+
+See the [Keycloak with Postgres Example](../postgresql/readme.md) for accessing the Keycloak with a port forward.
+
+You can then access the Keycloak Admin-Console via `https://id.acme.test/auth` with
+the username: `admin` and password: `secret`.
+
+# Remove Keycloak
+
+```
+helm uninstall keycloak
+helm uninstall keycloak-db
+```


### PR DESCRIPTION
Closes #599

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
