### PR TITLE
[keycloak] fix PodDisruption API selection

### DIFF
--- a/charts/keycloak/templates/poddisruptionbudget.yaml
+++ b/charts/keycloak/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget -}}
-{{- if semverCompare ">=1.21.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
`{{- if semverCompare ">=1.21.0" .Capabilities.KubeVersion.GitVersion }}` in PodDisruptionBudget template file (keycloak) does not work when Kubernetes gitversion uses pre-release notation (vX.Y.Z-pre.number for example), which is the case for GKE clusters.

This PR bases API selection on  `.Capabilities.APIVersions.Has` function.

Fixes https://github.com/codecentric/helm-charts/issues/607

Signed-off-by: Didier Hamels <didier.hamels@gmail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
