### PR TITLE
[keycloak] Bump postgres dependency chart version

### DIFF
--- a/charts/keycloak/.bumpversion.cfg
+++ b/charts/keycloak/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 18.1.1
+current_version = 18.2.0
 commit = true
 tag = false
 message = Bump keycloak chart version: {current_version} → {new_version}

--- a/charts/keycloak/.bumpversion.cfg
+++ b/charts/keycloak/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 18.2.0
+current_version = 18.1.1
 commit = true
 tag = false
 message = Bump keycloak chart version: {current_version} → {new_version}

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     email: thomas.darimont+github@gmail.com
 dependencies:
   - name: postgresql
-    version: 10.3.13
+    version: 10.16.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 18.2.0
+version: 18.1.1
 appVersion: 17.0.1-legacy
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 18.1.1
+version: 18.2.0
 appVersion: 17.0.1-legacy
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:


### PR DESCRIPTION
As Version 10.3.13 is not available anymore, i bumped to 10.16.2 - this is the latest release with the same appVersion as before and therefore shouln't break anything.