### PR TITLE
Increase postgresql dependency chart version

### DIFF
--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.13
-digest: sha256:0b35e861ab4e49a0d63eb83bf74a753a4b12d576d2d5f941701a659b4c93e1e4
-generated: "2021-10-02T08:07:05.761175+02:00"
+  version: 10.16.2
+digest: sha256:e09e206d81074a6540102fb62b8b12cf943c934c2af21e58ff8caa259690e87a
+generated: "2022-07-13T10:22:59.711349+02:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     email: thomas.darimont+github@gmail.com
 dependencies:
   - name: postgresql
-    version: 10.3.13
+    version: 10.16.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
Bitnami did some cleanup and removed old chart versions. Bumped it to the latest available version with the old appVersion, should not change anything.

Signed-off-by: Frederik Grieshaber <freddy.grieshaber+github@gmail.com>