### PR TITLE
fix: correct fallback when no existingSecret

### DIFF
--- a/charts/keycloakx/templates/_helpers.tpl
+++ b/charts/keycloakx/templates/_helpers.tpl
@@ -70,9 +70,7 @@ Create the service DNS name.
 - name: KC_DB_PASSWORD
   valueFrom:
     secretKeyRef:
-    {{- if .Values.database.existingSecret }}
       name: {{ .Values.database.existingSecret | default (printf "%s-database" (include "keycloak.fullname" . ))}}
-    {{- end }}
       key: password
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
Followup of: #601 

The previous setup resulted in the `name` missing when no existingSecret is provided:

```yaml
 name: KC_DB_PASSWORD
  valueFrom:
    secretKeyRef:
      key: password
```

Since `{{- if .Values.database.existingSecret }}` is then false and the whole thing is skipped.