### PR TITLE
docs: updates keycloakx readme about creating the admin user

### DIFF
--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -319,10 +319,21 @@ database:
 The Keycloak-X Docker image supports creating an initial admin user.
 It must be configured via environment variables:
 
-* `KC_DB_USERNAME` or `KC_DB_USERNAME_FILE`
-* `KC_DB_PASSWORD` or `KC_DB_PASSWORD_FILE`
+* `KEYCLOAK_ADMIN`
+* `KEYCLOAK_ADMIN_PASSWORD`
 
-Please refer to the section on database configuration for how to configure a secret for this.
+This can be done like so in the `values.yaml`, where the `KEYCLOAK_ADMIN` is an insecure example with the value in plaintext.
+The `KEYCLOAK_ADMIN_PASSWORD` is referenced from already existing secret but for testing it can be set with `value` too.
+```yaml
+extraEnv: |
+  - name: KEYCLOAK_ADMIN
+    value: admin
+  - name: KEYCLOAK_ADMIN_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: keycloak-admin-password
+        key: password
+```
 
 ### High Availability and Clustering
 


### PR DESCRIPTION
Since #621 was merged this doesn't reference anything:

> Please refer to the section on database configuration for how to configure a secret for this.

Also the environment variables look wrong to me (edit: not only me #605)? From the docs:

> use the KEYCLOAK_ADMIN and KEYCLOAK_ADMIN_PASSWORD environment variables to create an initial admin account.
>
> -- https://www.keycloak.org/docs/latest/server_admin/#creating-the-account-remotely

So here my attribution to the docs, feedback is of course welcome :)