### PR TITLE
feature: Allow setting mailhog replicas

### DIFF
--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -49,6 +49,7 @@ Parameter | Description | Default
 `auth.fileName` | The name of the auth file | `auth.txt`
 `auth.fileContents` | The contents of the auth file | `""`
 `nodeSelector` | Node labels for pod assignment | `{}`
+`podReplicas` | The number of pod replicas | `1`
 `podAnnotations` | Extra annotations to add to pod | `{}`
 `podLabels` | Extra labels to add to pod | `{}`
 `resources` | Pod resource requests and limits | `{}`

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "mailhog.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  replicas: {{ .Values.podReplicas }}
   selector:
     matchLabels:
       {{- include "mailhog.selectorLabels" . | nindent 6 }}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -94,6 +94,8 @@ outgoingSMTP:
     #   host: "mail2.example.com"
     #   port: "587"   # NOTE: go requires this port number to be a string... otherwise the container won't start
 
+podReplicas: 1
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
- Sets mailhog `spec.replicas` value, allows override via helm values
- Upstream update to `5.0.7`
- Uses `podReplicas` instead of `replicaCount` to match existing `podXYZ` variables

PR based on https://github.com/codecentric/helm-charts/pull/206 , credits to @bartlettt
