### PR TITLE
[mailhog] Add extraPorts in Service and extraContainers in Deployment

### DIFF
--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -63,7 +63,7 @@ Parameter | Description | Default
 `service.annotations` | Annotations for the service | `{}`
 `service.clusterIP` | Internal cluster service IP | `""`
 `service.externalIPs` | Service external IP addresses | `[]`
-`service.extraPorts` | Additional ports to be added service | `[]`
+`service.extraPorts` | Additional ports to the service | `[]`
 `service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `service.type` | Type of service to create | `ClusterIP`

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the Mailhog chart and t
 
 Parameter | Description | Default
 --- | --- | ---
+`extraContainers` | Additional containers to be added to the application pod | `[]`
 `image.repository` | Docker image repository | `mailhog/mailhog`
 `image.tag` | Docker image tag whose default is the chart version | `""`
 `image.pullPolicy` | Docker image pull policy | `IfNotPresent`
@@ -62,6 +63,7 @@ Parameter | Description | Default
 `service.annotations` | Annotations for the service | `{}`
 `service.clusterIP` | Internal cluster service IP | `""`
 `service.externalIPs` | Service external IP addresses | `[]`
+`service.extraPorts` | Additional ports to be added service | `[]`
 `service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `service.type` | Type of service to create | `ClusterIP`

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.extraContainers }}
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -86,6 +86,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/mailhog/templates/service.yaml
+++ b/charts/mailhog/templates/service.yaml
@@ -40,5 +40,8 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort.smtp))) }}
       nodePort: {{ .Values.service.nodePort.smtp }}
       {{- end }}
+    {{- if .Values.service.extraPorts }}
+      {{- toYaml .Values.service.extraPorts | nindent 4 }}
+    {{- end }}
   selector:
     {{- include "mailhog.selectorLabels" . | nindent 4 }}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -5,6 +5,8 @@ image:
 
 imagePullSecrets: []
 
+extraContainers: []
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -21,6 +23,7 @@ automountServiceAccountToken: false
 
 service:
   annotations: {}
+  extraPorts: []
   clusterIP: ""
   externalIPs: []
   loadBalancerIP: ""


### PR DESCRIPTION
When deploying the mailhog graph using ingress GCE the health check of Google's Load Balancer fails to succeed if the service is configured with basic auth.

This is because the health check is not able to set authentication parameters so that a request gets a return code of 200.
Also, even though there is an smtp port, the load balancer health check only has the ability to communicate via HTTP, HTTPS and HTTP2 protocol.
Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#direct_health

Therefore, the purpose of this change is to give the ability to add an extra container to be used only as a route for the Load Balancer life check to work, at the same time that mailhog basic authentication is enabled.

Signed-off-by: Julliano Goncalves <jullianow@gmail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
