### PR TITLE
[mailhog] Add ability to precisely control liveness and readiness probes

### DIFF
--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -56,6 +56,16 @@ Parameter | Description | Default
 `resources` | Pod resource requests and limits | `{}`
 `tolerations` | Node taints to tolerate | `[]`
 `priorityClassName` | Name of the existing priority class to be used by Mailhog pod, priority class needs to be created beforehand | `""`
+`livenessProbe.failureThreshold` | Failure threshold for livenessProbe | `3`
+`livenessProbe.initialDelaySeconds` | Initial delay seconds for livenessProbe | `10`
+`livenessProbe.periodSeconds` | Period seconds for livenessProbe | `10`
+`livenessProbe.successThreshold` | Success threshold for livenessProbe | `1`
+`livenessProbe.timeoutSeconds` | Timeout seconds for livenessProbe | `1`
+`readinessProbe.failureThreshold` | Failure threshold for readinessProbe | `3`
+`readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe | `10`
+`readinessProbe.periodSeconds` | Period seconds for readinessProbe | `10`
+`readinessProbe.successThreshold` | Success threshold for readinessProbe | `1`
+`readinessProbe.timeoutSeconds` | Timeout seconds for readinessProbe | `1`
 `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
 `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""` |
 `serviceAccount.imagePullSecrets` | Image pull secrets that are attached to the ServiceAccount | `[]` |

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -56,16 +56,8 @@ Parameter | Description | Default
 `resources` | Pod resource requests and limits | `{}`
 `tolerations` | Node taints to tolerate | `[]`
 `priorityClassName` | Name of the existing priority class to be used by Mailhog pod, priority class needs to be created beforehand | `""`
-`livenessProbe.failureThreshold` | Failure threshold for livenessProbe | `3`
-`livenessProbe.initialDelaySeconds` | Initial delay seconds for livenessProbe | `10`
-`livenessProbe.periodSeconds` | Period seconds for livenessProbe | `10`
-`livenessProbe.successThreshold` | Success threshold for livenessProbe | `1`
-`livenessProbe.timeoutSeconds` | Timeout seconds for livenessProbe | `1`
-`readinessProbe.failureThreshold` | Failure threshold for readinessProbe | `3`
-`readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe | `10`
-`readinessProbe.periodSeconds` | Period seconds for readinessProbe | `10`
-`readinessProbe.successThreshold` | Success threshold for readinessProbe | `1`
-`readinessProbe.timeoutSeconds` | Timeout seconds for readinessProbe | `1`
+`livenessProbe` | The Liveness Probe to add to pod | `{ "initialDelaySeconds": 10, "tcpPort": { "port": "tcp-smtp" }, "timeoutSeconds": 1 }`
+`readinessProbe` | The Readiness Probe to add to pod | `{"tcpPort": { "port": "tcp-smtp" }`
 `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
 `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""` |
 `serviceAccount.imagePullSecrets` | Image pull secrets that are attached to the ServiceAccount | `[]` |

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -62,12 +62,24 @@ spec:
           livenessProbe:
             tcpSocket:
               port: tcp-smtp
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
+            {{- with .Values.livenessProbe }}
+            failureThreshold: {{ .failureThreshold }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            successThreshold: {{ .successThreshold }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: tcp-smtp
-          {{ if or .Values.auth.enabled .Values.outgoingSMTP.enabled }}
+            {{- with .Values.readinessProbe }}
+            failureThreshold: {{ .failureThreshold }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            successThreshold: {{ .successThreshold }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            {{- end }}
+          {{- if or .Values.auth.enabled .Values.outgoingSMTP.enabled }}
           volumeMounts:
             {{- if .Values.auth.enabled }}
             - name: authdir

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -59,26 +59,12 @@ spec:
             - name: tcp-smtp
               containerPort: 1025
               protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: tcp-smtp
-            {{- with .Values.livenessProbe }}
-            failureThreshold: {{ .failureThreshold }}
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            successThreshold: {{ .successThreshold }}
-            timeoutSeconds: {{ .timeoutSeconds }}
-            {{- end }}
-          readinessProbe:
-            tcpSocket:
-              port: tcp-smtp
-            {{- with .Values.readinessProbe }}
-            failureThreshold: {{ .failureThreshold }}
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            successThreshold: {{ .successThreshold }}
-            timeoutSeconds: {{ .timeoutSeconds }}
-            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or .Values.auth.enabled .Values.outgoingSMTP.enabled }}
           volumeMounts:
             {{- if .Values.auth.enabled }}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -105,6 +105,21 @@ podLabels: {}
 
 extraEnv: []
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+livenessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
+readinessProbe:
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -107,18 +107,14 @@ extraEnv: []
 
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 livenessProbe:
-  failureThreshold: 3
+  tcpSocket:
+    port: 1025
   initialDelaySeconds: 10
-  periodSeconds: 10
-  successThreshold: 1
   timeoutSeconds: 1
 
 readinessProbe:
-  failureThreshold: 3
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  successThreshold: 1
-  timeoutSeconds: 1
+  tcpSocket:
+    port: 1025
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
In some use cases we need to have more control over the liveness probes on standby so that the container is available at the right time.
Also, in some cases, probes that vary the process in a short time, can produce many logs that we do not necessarily want.
Therefore, this change in the ability to set all existing properties to more precisely control with the liveliness and readiness probes should behave.

> **Note**
>
>All default values ​​are based on the documentation and what was already in use by the chart.

Signed-off-by: Julliano Goncalves <jullianow@gmail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
