### PR TITLE
[keycloakx] Don't trim the relative path when the path is just "/"

### DIFF
--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -86,7 +86,10 @@ spec:
           {{- tpl . $ | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.http.relativePath }}
+            {{- if and (.Values.http.relativePath) (eq .Values.http.relativePath "/")  }}
+            - name: KC_HTTP_RELATIVE_PATH
+              value: {{ tpl .Values.http.relativePath $ }}
+            {{ else }}
             - name: KC_HTTP_RELATIVE_PATH
               value: {{ tpl .Values.http.relativePath $ | trimSuffix "/" }}
             {{- end }}


### PR DESCRIPTION
A potential fix for bug #634.