### PR TITLE
[keycloak] [keycloakx] feat: Add integer to valid image tag type

### DIFF
--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 {{- define "keycloak.labels" -}}
 helm.sh/chart: {{ include "keycloak.chart" . }}
 {{ include "keycloak.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | trunc 63 | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -20,7 +20,7 @@
           "type": "string"
         },
         "tag": {
-          "type": "string"
+          "type": ["string", "integer"]
         }
       }
     },

--- a/charts/keycloakx/templates/_helpers.tpl
+++ b/charts/keycloakx/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Common labels
 {{- define "keycloak.labels" -}}
 helm.sh/chart: {{ include "keycloak.chart" . }}
 {{ include "keycloak.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | trunc 63 | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/keycloakx/values.schema.json
+++ b/charts/keycloakx/values.schema.json
@@ -20,7 +20,7 @@
           "type": "string"
         },
         "tag": {
-          "type": "string"
+          "type": ["string", "integer"]
         }
       }
     },


### PR DESCRIPTION
This PR adds `integer` as an valid input type for `image.tag` in keycloak and keycloakx chart.

Resolves #639 
