### PR TITLE
feat: only expose https ports when https port is defined in the service

### DIFF
--- a/charts/keycloakx/templates/service-http.yaml
+++ b/charts/keycloakx/templates/service-http.yaml
@@ -42,6 +42,7 @@ spec:
       nodePort: {{ .Values.service.httpNodePort }}
       {{- end }}
       protocol: TCP
+      {{- if .Values.service.httpsPort }}
     - name: https
       port: {{ .Values.service.httpsPort }}
       targetPort: https
@@ -49,6 +50,7 @@ spec:
       nodePort: {{ .Values.service.httpsNodePort }}
       {{- end }}
       protocol: TCP
+      {{- end }}
     {{- with .Values.service.extraPorts }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -145,9 +145,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.service.httpsPort }}
             - name: https
               containerPort: 8443
               protocol: TCP
+            {{- end }}
             {{- with .Values.extraPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
The https service and https containerports are typically not needed as most implementations will use the ingress with http backend communication. The https ports should therefore be disabled by default and not included in the service and statefulset. Only if someone manually sets a https port number via values, it should be exposed.
This also fixes some default prometheusrules which alert if service endpoints are not available.