### PR TITLE
[mailhog]: Add affinity configuration in README

### DIFF
--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -49,6 +49,7 @@ Parameter | Description | Default
 `auth.existingSecret` | If auth is enabled, uses an existing secret with this name; otherwise a secret is created | `""`
 `auth.fileName` | The name of the auth file | `auth.txt`
 `auth.fileContents` | The contents of the auth file | `""`
+`affinity` | Node affinity for pod assignment | `{}`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `podReplicas` | The number of pod replicas | `1`
 `podAnnotations` | Extra annotations to add to pod | `{}`


### PR DESCRIPTION
Pod affinity is provided in the `values.yaml` but it is not mentioned in the `README.md`.
This commit adds the key to the Helm Chart values table in the README.

Signed-off-by: Rishikesh Nair <42700059+rishinair11@users.noreply.github.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
