### PR TITLE
[keycloakx] Feat: Database key parameter add

### DIFF
--- a/charts/keycloakx/templates/_helpers.tpl
+++ b/charts/keycloakx/templates/_helpers.tpl
@@ -71,6 +71,6 @@ Create the service DNS name.
   valueFrom:
     secretKeyRef:
       name: {{ .Values.database.existingSecret | default (printf "%s-database" (include "keycloak.fullname" . ))}}
-      key: password
+      key: {{ .Values.database.existingSecretKey | default "password" }}
   {{- end }}
 {{- end -}}

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -369,6 +369,7 @@ database:
   # don't create secret for db password. Instead use existing k8s secret
   # existingSecret: "my-existent-dbpass-secret"
   existingSecret: ""
+  existingSecretKey: ""
   # E.g. dev-file, dev-mem, mariadb, mssql, mysql, oracle or postgres
   vendor:
   hostname:

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -368,6 +368,7 @@ dbchecker:
 database:
   # don't create secret for db password. Instead use existing k8s secret
   # existingSecret: "my-existent-dbpass-secret"
+  # existingSecretKey: "password"
   existingSecret: ""
   existingSecretKey: ""
   # E.g. dev-file, dev-mem, mariadb, mssql, mysql, oracle or postgres


### PR DESCRIPTION
Add the ability to specify the database secret key to a value other than 'password':

The vault will still default to 'password' with this pr, but enables extensibility of the chart. 
