### PR TITLE
[keycloak] env|From values schema and syntax updates

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak
-version: 18.4.0
+version: 18.4.1
 appVersion: 17.0.1-legacy
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -101,12 +101,12 @@ spec:
                   name: {{ include "keycloak.postgresql.fullname" . }}
                   key: postgresql-password
             {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- tpl . $ | nindent 12 }}
+            {{- if .Values.extraEnv }}
+            {{- .Values.extraEnv | toYaml | nindent 12 }}
             {{- end }}
           envFrom:
-            {{- with .Values.extraEnvFrom }}
-            {{- tpl . $ | nindent 12 }}
+            {{- if .Values.extraEnvFrom }}
+            {{- .Values.extraEnvFrom | toYaml | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -56,10 +56,10 @@
       "type": "string"
     },
     "extraEnv": {
-      "type": "string"
+      "type": "array"
     },
     "extraEnvFrom": {
-      "type": "string"
+      "type": "array"
     },
     "extraInitContainers": {
       "type": "string"

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -105,7 +105,7 @@ command: []
 args: []
 
 # Additional environment variables for Keycloak
-extraEnv: ""
+extraEnv: []
   # - name: KEYCLOAK_LOGLEVEL
   #   value: DEBUG
   # - name: WILDFLY_LOGLEVEL
@@ -116,7 +116,7 @@ extraEnv: ""
   #   value: "2"
 
 # Additional environment variables for Keycloak mapped from Secret or ConfigMap
-extraEnvFrom: ""
+extraEnvFrom: []
 
 #  Pod priority class name
 priorityClassName: ""


### PR DESCRIPTION
Signed-off-by: garcia.ryan <garcia.ryan@solute.us>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

Updating the schema and templating for `extraEnv` and `extraEnvFrom` values.

For issue #674
