### PR TITLE
comment ingress tls example to avoid conflicts

### DIFF
--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -298,11 +298,11 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
-  # TLS configuration
-  tls:
-    - hosts:
-        - keycloak.example.com
-      secretName: ""
+# Example TLS configuration
+#   tls:
+#     - hosts:
+#         - keycloak.example.com
+#       secretName: ""
 
   # ingress for console only (/auth/admin)
   console:


### PR DESCRIPTION
Hey!

I tried installing the helm chart with my values, I am advanced with helm, so I created my own values and ingress configuration, when I installed, I have noticed I encounter the error of:

```bash
Error syncing to GCP: error running load balancer syncing routine: error getting secrets for Ingress: secret "" does not exist
```

I never encountered this error so when googling I saw it is because I am using the GCE annotation in my ingress
```yaml
  annotations:
    networking.gke.io/managed-certificates: my-managed-certificate
    kubernetes.io/ingress.class: "gce"
```
and the tls configuration in the ingress:
```yaml
  tls:
    - hosts:
        - keycloak.example.com
      secretName: ""
```
got deployed to my ingress.

This PR will fix it as setting a tls config is not mandatory and there is other reasons to implement it to the ingress other than the forced implementation (like reverse proxies, etc.), I would appreciate it if this PR will be approved so I can clean my ingress config and as I am facing clients I would not want them to try figure it out the uanessacry troubleshooting it will cause.

Thanks,
Mike, a fellow DevOps Engineer. :)

Signed-off-by: Mike <90835468+justmike1@users.noreply.github.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
