### PR TITLE
Upgrade JGroups KUBE_PING extension to v2.0.1

### DIFF
--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/keycloak/keycloak:20.0.1
 
-ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
+ENV JGROUPS_KUBERNETES_VERSION 2.0.1.Final
 
-# Downlaod JGroups KubePing extension
+# Download JGroups KubePing extension
 RUN curl -s -L -o /opt/keycloak/providers/jgroups-kubernetes-$JGROUPS_KUBERNETES_VERSION.jar https://search.maven.org/remotecontent?filepath=org/jgroups/kubernetes/jgroups-kubernetes/$JGROUPS_KUBERNETES_VERSION/jgroups-kubernetes-$JGROUPS_KUBERNETES_VERSION.jar
 
 # Add custom kubeping configuration file


### PR DESCRIPTION
Where this version of KUBE_PING is build on top on JGroups v5.2, just like Keycloak v20: https://github.com/jgroups-extras/jgroups-kubernetes/compare/1.0.16.Final...2.0.1.Final#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8.