### PR TITLE
bump postgresql dependent chart version

### DIFF
--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.16.2
-digest: sha256:e09e206d81074a6540102fb62b8b12cf943c934c2af21e58ff8caa259690e87a
-generated: "2022-07-13T10:22:59.711349+02:00"
+  version: 11.6.2
+digest: sha256:1b96efc47b5dbe28bf34bcb694697325f3d2755a39ce2f1c371b2c9de9fac9d3
+generated: "2023-01-31T10:35:02.057263-07:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     email: thomas.darimont+github@gmail.com
 dependencies:
   - name: postgresql
-    version: 10.16.2
+    version: 11.6.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
Signed-off-by: Jimmy Ungerman <jimmy.ungerman@gmail.com>

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

Bump the postgresql dependent chart version to one still being hosted by bitnami.