### PR TITLE
Update deprecated autoscaling/v2beta2 api

### DIFF
--- a/charts/keycloakx/templates/hpa.yaml
+++ b/charts/keycloakx/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keycloak.fullname" . }}

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -491,7 +491,7 @@ prometheusRule:
   #     severity: warning
 
 autoscaling:
-  # If `true`, a autoscaling/v2beta2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)
+  # If `true`, an autoscaling/v2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)
   # Autoscaling seems to be most reliable when using KUBE_PING service discovery (see README for details)
   # This disables the `replicas` field in the StatefulSet
   enabled: false

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -491,7 +491,7 @@ prometheusRule:
   #     severity: warning
 
 autoscaling:
-  # If `true`, an autoscaling/v2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)
+  # If `true`, an autoscaling/v2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.23 or above)
   # Autoscaling seems to be most reliable when using KUBE_PING service discovery (see README for details)
   # This disables the `replicas` field in the StatefulSet
   enabled: false


### PR DESCRIPTION
The keycloakx chart is still using `autoscaling/v2beta2` for the HPA when autoscaling is enabled.

`autoscaling/v2beta2` has been deprecated since v1.23, and all k8s versions <= v1.23 are EOL.

I didn't make a PR to update the HPA API in the keycloak chart since it might make sense for that to remain on the legacy version. But I will make one if deemed appropriate.
