### PR TITLE
Updates HPA adding autoscaling/v2 compatibility

### DIFF
--- a/charts/keycloak/templates/hpa.yaml
+++ b/charts/keycloak/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version) }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keycloak.fullname" . }}

--- a/charts/keycloakx/templates/hpa.yaml
+++ b/charts/keycloakx/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.Version) }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keycloak.fullname" . }}


### PR DESCRIPTION
This adds HPA apiVersion `autoscaling/v2` when k8s version equals or is greater than 1.23.
For k8s < 1.23 the current `autoscaling/v2beta2` will still be used.

Signed-off-by: Cássio Tatsch <tatschcassio@gmail.com>