### PR TITLE
feat(keycloak) Enable Keycloak cluster nodes discovery by default

### DIFF
--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -101,6 +101,9 @@ spec:
                   name: {{ include "keycloak.postgresql.fullname" . }}
                   key: postgresql-password
             {{- end }}
+            {{- with .Values.jgroupsDiscovery }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- tpl . $ | nindent 12 }}
             {{- end }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -104,6 +104,13 @@ command: []
 ## Overrides the default args for the Keycloak container
 args: []
 
+# Environment variables for Keycloak to enable Keycloak cluster nodes discovery. The use of these is strongly advised if the chart is deployed with more than 1 replica or if autoscaling is enabled
+jgroupsDiscovery: |
+  - name: JGROUPS_DISCOVERY_PROTOCOL
+    value: "dns.DNS_PING"
+  - name: JGROUPS_DISCOVERY_PROPERTIES
+    value: "dns_query={{ include "keycloak.serviceDnsName" . }}"
+
 # Additional environment variables for Keycloak
 extraEnv: ""
   # - name: KEYCLOAK_LOGLEVEL


### PR DESCRIPTION
feat(keycloak) Include out-of-the-box high availability mechanism

While trying out the helm chart with replicas > 1, we've had the issue that
all keycloak instances don't identify each other to be part of the keycloak cluster.
This caused issues after logging in with multiple replicas. The problem lies in the missing distributed caching configuration. This change allows the helm chart to fully function with multiple replicas out of the box.

More information: https://www.keycloak.org/server/caching

Signed-off-by: Oswaldo Montenegro <oswaldo.montenegro@codecentric.de>