### PR TITLE
Use autoscaling/v2 api version if kubernetes version >= 1.23

### DIFF
--- a/charts/keycloak/templates/hpa.yaml
+++ b/charts/keycloak/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+{{- $apiVersion := "autoscaling/v2beta2" -}}
+{{- if semverCompare ">= v1.23.0-0" .Capabilities.KubeVersion.Version -}}
+  {{- $apiVersion = "autoscaling/v2" -}}
+{{- end }}
+apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keycloak.fullname" . }}
@@ -15,7 +19,7 @@ spec:
     name: {{ include "keycloak.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  metrics: 
+  metrics:
     {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
   behavior:
     {{- toYaml .Values.autoscaling.behavior | nindent 4 }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -466,7 +466,7 @@ prometheusRule:
   #     severity: warning
 
 autoscaling:
-  # If `true`, a autoscaling/v2beta2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)
+  # If `true`, a autoscaling/v2beta2 or autoscaling/v2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or 1.23 or above)
   # Autoscaling seems to be most reliable when using KUBE_PING service discovery (see README for details)
   # This disables the `replicas` field in the StatefulSet
   enabled: false


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
