### PR TITLE
[keycloak] README.md Postgresql

### DIFF
--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -774,7 +774,7 @@ Configuration is more generic making it easier to use custom Docker images that 
 
 * Values are no longer nested under `keycloak`.
 * Besides setting the node identifier, no CLI changes are performed out of the box
-* Environment variables for the Postresql dependency are set automatically if enabled.
+* Environment variables for the Postgresql dependency are set automatically if enabled.
   Otherwise, no environment variables are set by default.
 * Optionally enables creating RBAC resources with configurable rules (e. g. for KUBE_PING)
 * PostgreSQL chart dependency is updated to 9.1.1


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

- fixes: #739 
