### PR TITLE
Remove Keycloak JDK UseContainerSupport parameter

### DIFF
--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -267,7 +267,6 @@ This allows you to only configure memory using Kubernetes resources and the JVM 
 extraEnv: |
   - name: JAVA_OPTS
     value: >-
-      -XX:+UseContainerSupport
       -XX:MaxRAMPercentage=50.0
       -Djava.awt.headless=true
 ```
@@ -275,6 +274,8 @@ extraEnv: |
 Alternatively one can append custom JVM options by setting the `JAVA_OPTS_APPEND` environment variable.
 
 The parameter `-Djava.net.preferIPv4Stack=true` is [optional](https://github.com/keycloak/keycloak/commit/ee205c8fbc1846f679bd604fa8d25310c117c87e) for [Keycloak >= v22](https://www.keycloak.org/server/configuration-production#_configure_keycloak_server_with_ipv4_or_ipv6).
+
+The parameter `-XX:+UseContainerSupport` is no longer required for [Keycloak >= v21 based on JDK v17](https://github.com/keycloak/keycloak/blob/release/21.0/quarkus/container/Dockerfile#L20).
 
 #### Using an External Database
 

--- a/charts/keycloakx/ci/h2-values.yaml
+++ b/charts/keycloakx/ci/h2-values.yaml
@@ -17,7 +17,6 @@ extraEnv: |
         key: password
   - name: JAVA_OPTS_APPEND
     value: >-
-      -XX:+UseContainerSupport
       -XX:MaxRAMPercentage=50.0
       -Djava.awt.headless=true
       -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless

--- a/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
@@ -35,7 +35,6 @@ extraEnv: |
         key: password
   - name: JAVA_OPTS_APPEND
     value: >-
-      -XX:+UseContainerSupport
       -XX:MaxRAMPercentage=50.0
       -Djava.awt.headless=true
       -Dkubeping_namespace={{ .Release.Namespace }}

--- a/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
@@ -23,7 +23,6 @@ extraEnv: |
         key: password
   - name: JAVA_OPTS_APPEND
     value: >-
-      -XX:+UseContainerSupport
       -XX:MaxRAMPercentage=50.0
       -Djava.awt.headless=true
       -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless


### PR DESCRIPTION
The parameter `-XX:+UseContainerSupport` is no longer required for Keycloak >= v21 based on JDK v17. JDK >= v17 has enabled the container support by default.

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
