### PR TITLE
Remove the JDK parameter java.awt.headless=true

### DIFF
--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -268,7 +268,6 @@ extraEnv: |
   - name: JAVA_OPTS
     value: >-
       -XX:MaxRAMPercentage=50.0
-      -Djava.awt.headless=true
 ```
 
 Alternatively one can append custom JVM options by setting the `JAVA_OPTS_APPEND` environment variable.
@@ -276,6 +275,8 @@ Alternatively one can append custom JVM options by setting the `JAVA_OPTS_APPEND
 The parameter `-Djava.net.preferIPv4Stack=true` is [optional](https://github.com/keycloak/keycloak/commit/ee205c8fbc1846f679bd604fa8d25310c117c87e) for [Keycloak >= v22](https://www.keycloak.org/server/configuration-production#_configure_keycloak_server_with_ipv4_or_ipv6).
 
 The parameter `-XX:+UseContainerSupport` is no longer required for [Keycloak >= v21 based on JDK v17](https://github.com/keycloak/keycloak/blob/release/21.0/quarkus/container/Dockerfile#L20).
+
+The parameter `-Djava.awt.headless=true` is no longer required for Quarkus based Keycloak as it is set by [default](https://quarkus.io/guides/building-native-image).
 
 #### Using an External Database
 

--- a/charts/keycloakx/ci/h2-values.yaml
+++ b/charts/keycloakx/ci/h2-values.yaml
@@ -18,7 +18,6 @@ extraEnv: |
   - name: JAVA_OPTS_APPEND
     value: >-
       -XX:MaxRAMPercentage=50.0
-      -Djava.awt.headless=true
       -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
 
 database:

--- a/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
@@ -36,7 +36,6 @@ extraEnv: |
   - name: JAVA_OPTS_APPEND
     value: >-
       -XX:MaxRAMPercentage=50.0
-      -Djava.awt.headless=true
       -Dkubeping_namespace={{ .Release.Namespace }}
       -Dkubeping_label="keycloak-cluster=default"
 

--- a/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
@@ -24,7 +24,6 @@ extraEnv: |
   - name: JAVA_OPTS_APPEND
     value: >-
       -XX:MaxRAMPercentage=50.0
-      -Djava.awt.headless=true
       -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
 
 dbchecker:


### PR DESCRIPTION
There is a a lot of evidence that the parameter is set to `java.awt.headless=true` in Quarkus by default.

* Quarkus Building native Images: https://quarkus.io/guides/building-native-image) see default value for `java.awt.headless`
* https://github.com/quarkusio/quarkus/issues/20565
* https://github.com/quarkusio/quarkus/pull/20850

