### PR TITLE
feat(keycloakx): Upgrade Keycloak to 24.0.3

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
 version: 2.3.0
-appVersion: 22.0.4
+appVersion: 24.0.3
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.4
+FROM quay.io/keycloak/keycloak:24.0.3
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "22.0.4"
+  tag: "24.0.3"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
Resolves #756

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
