### PR TITLE
WIP: Update Helm Chart to use Keycloak 25.x.x

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 2.3.0
-appVersion: 22.0.4
+version: 3.0.0
+appVersion: 25.0.0
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.4
+FROM quay.io/keycloak/keycloak:25.0.0
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -99,10 +99,7 @@ spec:
             - name: KC_CACHE_STACK
               value: "kubernetes"
             {{- end }}
-            {{- if .Values.proxy.enabled }}
-            - name: KC_PROXY
-              value: {{ .Values.proxy.mode }}
-            {{- end }}
+
             {{- if .Values.database.vendor }}
             - name: KC_DB
               value: {{ .Values.database.vendor }}

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -415,9 +415,10 @@ cache:
   # Use "custom" to disable automatic cache configuration
   stack: default
 
+# TODO: this might not work anymore as it is turned on by default and if you set to false it will be still be turn on
 metrics:
   enabled: true
-
+# TODO: this might not work anymore as it is turned on by default and if you set to false it will be still be turn on
 health:
   enabled: true
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -107,6 +107,13 @@ clusterDomain: cluster.local
 ## Overrides the default entrypoint of the Keycloak container
 ## This change also means you cannot invoke kc.sh using a single quoted value of all arguments. 
 ## https://www.keycloak.org/docs/latest/upgrading/index.html#kc-sh-and-shell-metacharacters
+
+## Proxy modes
+# kc.sh (no proxy option set) --> kc.sh
+# kc.sh --proxy none  --> kc.sh
+# kc.sh --proxy edge --> kc.sh --proxy-headers forwarded|xforwarded --http-enabled true
+# kc.sh --proxy passthrough --> kc.sh --hostname-port 80|443 (depending if HTTPS is used)
+# kc.sh --proxy reencrypt --> kc.sh --proxy-headers forwarded|xforwarded
 command: []
 
 ## Overrides the default args for the Keycloak container
@@ -407,10 +414,6 @@ database:
 cache:
   # Use "custom" to disable automatic cache configuration
   stack: default
-
-proxy:
-  enabled: true
-  mode: edge
 
 metrics:
   enabled: true

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "22.0.4"
+  tag: "25.0.0"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -105,9 +105,13 @@ terminationGracePeriodSeconds: 60
 clusterDomain: cluster.local
 
 ## Overrides the default entrypoint of the Keycloak container
+## This change also means you cannot invoke kc.sh using a single quoted value of all arguments. 
+## https://www.keycloak.org/docs/latest/upgrading/index.html#kc-sh-and-shell-metacharacters
 command: []
 
 ## Overrides the default args for the Keycloak container
+## This change also means you cannot invoke kc.sh using a single quoted value of all arguments. 
+## https://www.keycloak.org/docs/latest/upgrading/index.html#kc-sh-and-shell-metacharacters
 args: []
 
 # Additional environment variables for Keycloak


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
