### PR TITLE
Upgraded to version 25.0.0 of Keycloak

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
 version: 2.3.0
-appVersion: 22.0.4
+appVersion: 25.0.0
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -11,7 +11,6 @@ $ cat << EOF > values.yaml
 command:
   - "/opt/keycloak/bin/kc.sh"
   - "start"
-  - "--http-enabled=true"
   - "--http-port=8080"
   - "--hostname-strict=false"
 extraEnv: |

--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -14,7 +14,6 @@ command:
   - "--http-enabled=true"
   - "--http-port=8080"
   - "--hostname-strict=false"
-  - "--hostname-strict-https=false"
 extraEnv: |
   - name: KEYCLOAK_ADMIN
     value: admin

--- a/charts/keycloakx/ci/h2-values.yaml
+++ b/charts/keycloakx/ci/h2-values.yaml
@@ -3,7 +3,6 @@ command:
   - "--verbose"
   - "start"
   - --hostname-strict=false
-  - --hostname-strict-https=false
 
 extraEnv: |
   - name: KEYCLOAK_ADMIN

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.4
+FROM quay.io/keycloak/keycloak:25.0.0
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
@@ -8,7 +8,6 @@ command:
   - "--http-enabled=true"
   - "--http-port=8080"
   - "--hostname-strict=false"
-  - "--hostname-strict-https=false"
   - "--spi-events-listener-jboss-logging-success-level=info"
   - "--spi-events-listener-jboss-logging-error-level=warn"
 

--- a/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql-kubeping/keycloak-server-values.yaml
@@ -5,7 +5,6 @@ command:
   - "/opt/keycloak/bin/kc.sh"
   - "--verbose"
   - "start"
-  - "--http-enabled=true"
   - "--http-port=8080"
   - "--hostname-strict=false"
   - "--spi-events-listener-jboss-logging-success-level=info"

--- a/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
@@ -8,7 +8,6 @@ command:
   - "--http-enabled=true"
   - "--http-port=8080"
   - "--hostname-strict=false"
-  - "--hostname-strict-https=false"
   - "--spi-events-listener-jboss-logging-success-level=info"
   - "--spi-events-listener-jboss-logging-error-level=warn"
 

--- a/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
+++ b/charts/keycloakx/examples/postgresql/keycloak-server-values.yaml
@@ -5,7 +5,6 @@ command:
   - "/opt/keycloak/bin/kc.sh"
   - "--verbose"
   - "start"
-  - "--http-enabled=true"
   - "--http-port=8080"
   - "--hostname-strict=false"
   - "--spi-events-listener-jboss-logging-success-level=info"

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -100,8 +100,12 @@ spec:
               value: "kubernetes"
             {{- end }}
             {{- if .Values.proxy.enabled }}
-            - name: KC_PROXY
+            - name: KC_PROXY_HEADERS
               value: {{ .Values.proxy.mode }}
+            {{- end }}
+            {{- if .Values.proxy.http.enabled }}
+            - name: KC_HTTP_ENABLED
+              value: "true"
             {{- end }}
             {{- if .Values.database.vendor }}
             - name: KC_DB

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -145,6 +145,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: http-internal
+              containerPort: 9000
+              protocol: TCP
             {{- if .Values.service.httpsPort }}
             - name: https
               containerPort: 8443

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -145,7 +145,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            - name: http-internal
+            - name: '{{ .Values.http.internalPort }}'
               containerPort: 9000
               protocol: TCP
             {{- if .Values.service.httpsPort }}

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -166,7 +166,7 @@ podAnnotations: {}
 livenessProbe: |
   httpGet:
     path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/live'
-    port: http-internal
+    port: '{{ .Values.http.internalPort }}'
   initialDelaySeconds: 0
   timeoutSeconds: 5
 
@@ -174,7 +174,7 @@ livenessProbe: |
 readinessProbe: |
   httpGet:
     path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/ready'
-    port: http-internal
+    port: '{{ .Values.http.internalPort }}'
   initialDelaySeconds: 10
   timeoutSeconds: 1
 
@@ -182,7 +182,7 @@ readinessProbe: |
 startupProbe: |
   httpGet:
     path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health'
-    port: http-internal
+    port: '{{ .Values.http.internalPort }}'
   initialDelaySeconds: 15
   timeoutSeconds: 1
   failureThreshold: 60
@@ -417,6 +417,7 @@ health:
 http:
   # For backwards compatibility reasons we set this to the value used by previous Keycloak versions.
   relativePath: "/auth"
+  internalPort: http-internal
 
 serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
@@ -436,7 +437,7 @@ serviceMonitor:
   # The path at which metrics are served
   path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/metrics'
   # The Service port at which metrics are served
-  port: http-internal
+  port: '{{ .Values.http.internalPort }}'
 
 extraServiceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
@@ -456,7 +457,7 @@ extraServiceMonitor:
   # The path at which metrics are served
   path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/metrics'
   # The Service port at which metrics are served
-  port: http-internal
+  port: '{{ .Values.http.internalPort }}'
 
 prometheusRule:
   # If `true`, a PrometheusRule resource for the prometheus-operator is created

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "22.0.4"
+  tag: "25.0.0"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy
@@ -166,7 +166,7 @@ podAnnotations: {}
 livenessProbe: |
   httpGet:
     path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/live'
-    port: http
+    port: http-internal
   initialDelaySeconds: 0
   timeoutSeconds: 5
 
@@ -174,7 +174,7 @@ livenessProbe: |
 readinessProbe: |
   httpGet:
     path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health/ready'
-    port: http
+    port: http-internal
   initialDelaySeconds: 10
   timeoutSeconds: 1
 
@@ -182,7 +182,7 @@ readinessProbe: |
 startupProbe: |
   httpGet:
     path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/health'
-    port: http
+    port: http-internal
   initialDelaySeconds: 15
   timeoutSeconds: 1
   failureThreshold: 60
@@ -436,7 +436,7 @@ serviceMonitor:
   # The path at which metrics are served
   path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/metrics'
   # The Service port at which metrics are served
-  port: http
+  port: http-internal
 
 extraServiceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created
@@ -454,9 +454,9 @@ extraServiceMonitor:
   # Timeout for scraping
   scrapeTimeout: 10s
   # The path at which metrics are served
-  path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/realms/master/metrics'
+  path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/metrics'
   # The Service port at which metrics are served
-  port: http
+  port: http-internal
 
 prometheusRule:
   # If `true`, a PrometheusRule resource for the prometheus-operator is created

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -406,7 +406,9 @@ cache:
 
 proxy:
   enabled: true
-  mode: edge
+  mode: forwarded
+  http:
+    enabled: true
 
 metrics:
   enabled: true


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

Upgraded to version 25.0.0 of Keycloak. Tested in separate systems, and only change needed was to use the new internal 9000 port for health checks and metrics.