### PR TITLE
add support for compatibility to run this chart in openshift

### DIFF
--- a/charts/keycloakx/templates/_helpers.tpl
+++ b/charts/keycloakx/templates/_helpers.tpl
@@ -74,3 +74,39 @@ Create the service DNS name.
       key: {{ .Values.database.existingSecretKey | default "password" }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Return true if the detected platform is Openshift
+Usage:
+{{- include "common.compatibility.isOpenshift" . -}}
+*/}}
+{{- define "keycloak.isOpenshift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render a compatible securityContext depending on the platform. By default it is maintained as it is. In other platforms like Openshift we remove default user/group values that do not work out of the box with the restricted-v1 SCC
+Usage:
+{{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) -}}
+*/}}
+{{- define "keycloak.renderSecurityContext" -}}
+{{- $adaptedContext := .secContext -}}
+
+{{- if (((.context.Values).compatibility).openshift) -}}
+  {{- if or (eq .context.Values.compatibility.openshift.adaptSecurityContext "force") (and (eq .context.Values.compatibility.openshift.adaptSecurityContext "auto") (include "keycloak.isOpenshift" .context)) -}}
+    {{/* Remove incompatible user/group values that do not work in Openshift out of the box */}}
+    {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
+    {{- if not .secContext.seLinuxOptions -}}
+    {{/* If it is an empty object, we remove it from the resulting context because it causes validation issues */}}
+    {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{/* Remove fields that are disregarded when running the container in privileged mode */}}
+{{- if $adaptedContext.privileged -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}
+{{- end -}}
+{{- omit $adaptedContext "enabled" | toYaml -}}
+{{- end -}}

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -46,8 +46,9 @@ spec:
         - name: dbchecker
           image: "{{ .Values.dbchecker.image.repository }}{{- if (.Values.dbchecker.image.digest) -}}@{{ .Values.dbchecker.image.digest }}{{- else -}}:{{ .Values.dbchecker.image.tag }} {{- end }}"
           imagePullPolicy: {{ .Values.dbchecker.image.pullPolicy }}
-          securityContext:
-            {{- toYaml .Values.dbchecker.securityContext | nindent 12 }}
+          {{- if .Values.podSecurityContext.enabled }}
+          securityContext: {{- include "keycloak.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -69,8 +70,9 @@ spec:
     {{- end }}
       containers:
         - name: keycloak
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext: {{- include "keycloak.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}{{- if (.Values.image.digest) -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag | default .Chart.AppVersion }} {{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.command }}
@@ -190,8 +192,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "keycloak.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- include "keycloak.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -68,12 +68,22 @@ rbac:
   #      - get
   #      - list
 
+compatibility:
+  ## Compatibility adaptations for Openshift
+  ##
+  openshift:
+    ## @param compatibility.openshift.adaptSecurityContext Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+    ##
+    adaptSecurityContext: auto
+
 # SecurityContext for the entire Pod. Every container running in the Pod will inherit this SecurityContext. This might be relevant when other components of the environment inject additional containers into running Pods (service meshes are the most prominent example for this)
 podSecurityContext:
+  enabled: true
   fsGroup: 1000
 
 # SecurityContext for the Keycloak container
 securityContext:
+  enabled: true
   runAsUser: 1000
   runAsNonRoot: true
 


### PR DESCRIPTION
This change adds compatibility with OpenShift. I changed the rendering of security contexts to be able to run in OpenShift without setting UID and GID for the container. Code is copied from Bitnami charts repository which uses Apache License. It also keeps backward compatibility with previous versions.
