### PR TITLE
Fix servicemonitor http endpoint

### DIFF
--- a/charts/keycloakx/templates/servicemonitor.yaml
+++ b/charts/keycloakx/templates/servicemonitor.yaml
@@ -34,7 +34,7 @@ spec:
   endpoints:
     - port: {{ tpl .port $ | quote }}
       path: {{ tpl .path $ | quote }}
-      scheme: {{ .Values.http.internalScheme | lower }}
+      scheme: {{ $.Values.http.internalScheme | lower }}
       interval: {{ .interval }}
       scrapeTimeout: {{ .scrapeTimeout }}
 {{- end }}


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
Fix issue with servicemonitor trying to read .Values within a loop

Reproduction before fix

```sh
❯ helm template --set extraServiceMonitor.enabled=true ./
Error: template: keycloakx/templates/servicemonitor.yaml:37:24: executing "keycloakx/templates/servicemonitor.yaml" at <.Values.http.internalScheme>: nil pointer evaluating interface {}.http
```