### PR TITLE
[keycloakx/keycloak 25] add internalPort to service-http.yaml

### DIFF
--- a/charts/keycloakx/templates/service-http.yaml
+++ b/charts/keycloakx/templates/service-http.yaml
@@ -35,6 +35,10 @@ spec:
   {{- end }}
   {{- end }}
   ports:
+    - name: '{{ .Values.http.internalPort }}'
+      port: 9000
+      protocol: TCP
+      targetPort: '{{ .Values.http.internalPort }}' 
     - name: http
       port: {{ .Values.service.httpPort }}
       targetPort: http


### PR DESCRIPTION
#796 

To be able to get the metrics including the UP metric it is necessary to add the metrics endpoint/port to the service itself.

