### PR TITLE
feature: publish to GHCR registry

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.16.1
+          version: v3.16.3
 
       - name: Add dependency chart repos
         run: |
@@ -102,5 +102,5 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" oci://ghcr.io/jonesbusy/helm-charts
+            helm push "${pkg}" oci://ghcr.io/codecentric/helm-charts
           done

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -102,5 +102,5 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" oci://ghcr.io/codecentric/helm-charts
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}
           done

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -9,6 +9,11 @@ on:
     # every friday at 4 o'clock
     - cron: '0 16 * * 5'
   workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   bump-versions:
     runs-on: ubuntu-latest
@@ -71,11 +76,18 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.1
+          version: v3.16.1
 
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release charts
         uses: helm/chart-releaser-action@v1.5.0
@@ -83,3 +95,12 @@ jobs:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"          
+
+      - name: Push Chart to GHCR
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/jonesbusy/helm-charts
+          done

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Once Helm is set up properly, add the repo as follows:
 $ helm repo add codecentric https://codecentric.github.io/helm-charts
 ```
 
+Helm chart are also published to GitHub container registry as OCI artifact.
+
 ## Contributing
 
 We welcome contributions.

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -8,6 +8,12 @@
 $ helm install keycloak codecentric/keycloak
 ```
 
+or via GitHub Container Registry:
+
+```console
+$ helm install keycloak oci://ghcr.io/codecentric/helm-charts/keycloak --version <version>
+```
+
 ## Introduction
 
 This chart bootstraps a [Keycloak](http://www.keycloak.org/) StatefulSet on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.

--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -44,6 +44,12 @@ To install the chart with the release name `keycloakx`:
 $ helm install keycloak codecentric/keycloakx
 ```
 
+or via GitHub Container Registry:
+
+```console
+$ helm install keycloak oci://ghcr.io/codecentric/helm-charts/keycloakx --version <version>
+```
+
 ## Uninstalling the Chart
 
 To uninstall the `keycloakx` deployment:

--- a/charts/mailhog/README.md
+++ b/charts/mailhog/README.md
@@ -22,6 +22,12 @@ To install the chart with the release name `mailhog`:
 $ helm install mailhog codecentric/mailhog
 ```
 
+or via GitHub Container Registry:
+
+```console
+$ helm install mailhog oci://ghcr.io/codecentric/helm-charts/mailhog --version <version>
+```
+
 The command deploys Mailhog on the Kubernetes cluster in the default configuration. The [configuration](#configuration)
 section lists the parameters that can be configured during installation.
 


### PR DESCRIPTION
Fix : https://github.com/codecentric/helm-charts/issues/797

Charts will now be published in addition to traditional helm deployment also in GitHub container registry to be consumed by OCI client or directly since Helm 3.8

I've tested the release on my fork

![release_process1](https://github.com/user-attachments/assets/f079ad6d-57a1-4dbd-9b8a-65b19caa25f4)

This is similar to other OpenSource charts: https://github.com/jenkinsci/helm-charts/pull/1196 or https://github.com/sigstore/helm-charts/pull/43

Hope this contribution will be accepted so that we can proxy/pull such OCI artifact 
