### PR TITLE
[keycloakx] [keycloak] feat: Add support for minReadySeconds configuration

### DIFF
--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -24,6 +24,9 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -34,6 +34,9 @@ podManagementPolicy: Parallel
 # StatefulSet's update strategy
 updateStrategy: RollingUpdate
 
+# StatefulSet's minReadySeconds configuration
+minReadySeconds: ""
+
 # Pod restart policy. One of `Always`, `OnFailure`, or `Never`
 restartPolicy: Always
 

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -25,6 +25,9 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -36,6 +36,9 @@ podManagementPolicy: OrderedReady
 # StatefulSet's update strategy
 updateStrategy: RollingUpdate
 
+# StatefulSet's minReadySeconds configuration
+minReadySeconds: ""
+
 # Pod restart policy. One of `Always`, `OnFailure`, or `Never`
 restartPolicy: Always
 


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

This PR allows to configure [minReadySeconds](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds) for keycloak statefulset.