### PR TITLE
just lint the keycloakx chart

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,7 @@
 remote: origin
 target-branch: master
 chart-dirs:
-  - charts
+  - charts/keycloakx
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 check-version-increment: false


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
