### PR TITLE
just lint the keycloakx chart

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,7 @@
 remote: origin
 target-branch: master
 chart-dirs:
-  - charts
+  - charts/keycloakx
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 check-version-increment: false


### PR DESCRIPTION
It seems like the old keycloak chart can't be built due to some changes in the bitnami Repository. I think the old charts can be deprecated. For now we stop linting the other charts 

https://github.com/codecentric/helm-charts/actions/runs/11853000905/job/33032242686