### PR TITLE
[keycloakx/keycloak 25/26] Adds internal management port to service temp…

### DIFF
--- a/charts/keycloakx/templates/service-http.yaml
+++ b/charts/keycloakx/templates/service-http.yaml
@@ -35,6 +35,10 @@ spec:
   {{- end }}
   {{- end }}
   ports:
+    - name: '{{ .Values.http.internalPort }}'
+      port: 9000
+      protocol: TCP
+      targetPort: '{{ .Values.http.internalPort }}'
     - name: http
       port: {{ .Values.service.httpPort }}
       targetPort: http


### PR DESCRIPTION
Adds the management port to the list of ports in the service template. Its needed in order for the Prometheus Operator to gather metrics.

Closes #796 

Its based on PR #798 which was closed due to inactivity. Credits to @Tim-Schwalbe for providing the PR in the first place 🙂 