### PR TITLE
chore(github): Generate release notes

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -97,7 +97,8 @@ jobs:
         with:
           charts_dir: charts
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"          
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true
 
       - name: Push Chart to GHCR
         run: |


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

ChartReleaser can add (meaningful) releasenotes to the GitHub releases. Without it, it only prints the description of the chart which is not very helpful (especially not when using tools like Renovate)