### PR TITLE
feat: bump keycloak to 26.2.3 due CVE

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 7.0.1
-appVersion: 26.0.7
+version: 7.1.0
+appVersion: 26.2.3
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.0.7
+FROM quay.io/keycloak/keycloak:26.2.3
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.0.7"
+  tag: "26.2.3"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
There have been several CVE since the version currently in the chart:
https://github.com/keycloak/keycloak/security

Is `microhaug` broken? Previously that would automatically bump the chart