### PR TITLE
[mailhog] add commonLabels to chart

### DIFF
--- a/charts/mailhog/templates/_helpers.tpl
+++ b/charts/mailhog/templates/_helpers.tpl
@@ -39,6 +39,9 @@ helm.sh/chart: {{ include "mailhog.chart" . }}
 {{ include "mailhog.selectorLabels" . }}
 app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | trunc 63 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/mailhog/templates/deployment.yaml
+++ b/charts/mailhog/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       {{- end }}
       labels:
         {{- include "mailhog.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -108,6 +108,8 @@ outgoingSMTP:
     #   host: "mail2.example.com"
     #   port: "587"   # NOTE: go requires this port number to be a string... otherwise the container won't start
 
+commonLabels: {}
+
 podReplicas: 1
 
 podAnnotations: {}


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

Adds `commonLabels` so that you can add labels to all resources easily, useful for e.g. if you need to comply with an admission policy that requires ownership labels.