### PR TITLE
Enable RelabelConfigs to apply to samples before scraping

### DIFF
--- a/charts/keycloak/templates/servicemonitor.yaml
+++ b/charts/keycloak/templates/servicemonitor.yaml
@@ -34,6 +34,7 @@ spec:
       path: {{ .path }}
       interval: {{ .interval }}
       scrapeTimeout: {{ .scrapeTimeout }}
+      relabelings: {{ .relabelings }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -406,6 +406,8 @@ serviceMonitor:
   annotations: {}
   # Additional labels for the ServiceMonitor
   labels: {}
+  # RelabelConfigs to apply to samples before scraping
+  relabelings: {}
   # Interval at which Prometheus scrapes metrics
   interval: 10s
   # Timeout for scraping


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
The goal of this PR is to enable adding and updating labels in serviceMonitor. The features is needed, when we have multiple environments and we would like to enable specific labels for instance of Keycloak in each environment.