### PR TITLE
Port "allow to deploy ingress without host specified" to KeycloakX

### DIFF
--- a/charts/keycloakx/templates/ingress.yaml
+++ b/charts/keycloakx/templates/ingress.yaml
@@ -35,7 +35,10 @@ spec:
 {{- end }}
   rules:
     {{- range .Values.ingress.rules }}
-    - host: {{ tpl .host $ | quote }}
+    -
+      {{- if .host }}
+      host: {{ tpl .host $ | quote }}
+      {{- end }}
       http:
         paths:
           {{- range .paths }}
@@ -95,7 +98,10 @@ spec:
 {{- end }}
   rules:
     {{- range .Values.ingress.console.rules }}
-    - host: {{ tpl .host $ | quote }}
+    -
+      {{- if .host }}
+      host: {{ tpl .host $ | quote }}
+      {{- end }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
This is of port of 1301374d19d754b32b0a68bb055d96e53bca650b to the keycloak-x chart.

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
