### PR TITLE
Bump Chart to 7.1.2

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloakx
-version: 7.1.1
+version: 7.1.2
 appVersion: 26.3.2
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
