### PR TITLE
[keycloakx] hotfix on incorrect templating of serviceHeadless.extraPorts

### DIFF
--- a/charts/keycloakx/templates/service-headless.yaml
+++ b/charts/keycloakx/templates/service-headless.yaml
@@ -20,7 +20,7 @@ spec:
       port: {{ .Values.service.httpPort }}
       targetPort: http
       protocol: TCP
-    {{- range .Values.serviceHeadless.extraPorts }}
+    {{- with .Values.serviceHeadless.extraPorts }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   selector:


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->

Hotfix on the new feature introduced in #847, which originates from #835.

Replaced incorrect use of the `range` template with `with` template.