### PR TITLE
fix: Removal of a default TLS for the Keycloak ingress on values file

### DIFF
--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -305,10 +305,10 @@ ingress:
         - path: '{{ tpl .Values.http.relativePath $ | trimSuffix "/" }}/'
           pathType: Prefix
   # TLS configuration
-  tls:
-    - hosts:
-        - keycloak.example.com
-      secretName: ""
+  tls: []
+  #  - hosts:
+  #      - keycloak.example.com
+  #    secretName: ""
 
   # ingress for console only (/auth/admin)
   console:
@@ -330,9 +330,9 @@ ingress:
 
     # Console TLS configuration
     tls: []
-#      - hosts:
-#          - console.keycloak.example.com
-#        secretName: ""
+    # - hosts:
+    #     - console.keycloak.example.com
+    #   secretName: ""
 
 ## Network policy configuration
 # https://kubernetes.io/docs/concepts/services-networking/network-policies/


### PR DESCRIPTION
Hello,

When managing certificates through ingress annotations, with the current version it is impossible to remove the default tls section on the Keycloak ingress.

In my case, I manage the certificate part through my Azure Application Gateway and its controller on AKS.

Bad output :

```
# Source: keycloakx/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: keycloak
  namespace: default
  annotations:
    appgw.ingress.kubernetes.io/cookie-based-affinity: "true"
    appgw.ingress.kubernetes.io/ssl-redirect: "true"
    appgw.ingress.kubernetes.io/appgw-ssl-certificate: "cert-xx"
  labels:
    helm.sh/chart: keycloakx-7.1.4
    app.kubernetes.io/name: keycloakx
    app.kubernetes.io/instance: keycloak
    app.kubernetes.io/version: "26.4.2"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: azure-application-gateway
  tls: <-- BAD : Default values
    - hosts:
        - "keycloak.example.com"
  rules:
    - host: "keycloak.domain.com"
      http:
        paths:
          - path: "/"
            pathType: Prefix
            backend:
              service:
                name: keycloak-http
                port:
                  name: http
```

Good output : 

```
# Source: keycloakx/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: keycloak
  namespace: default
  annotations:
    appgw.ingress.kubernetes.io/cookie-based-affinity: "true"
    appgw.ingress.kubernetes.io/ssl-redirect: "true"
    appgw.ingress.kubernetes.io/appgw-ssl-certificate: "cert-xx"
  labels:
    helm.sh/chart: keycloakx-7.1.4
    app.kubernetes.io/name: keycloakx
    app.kubernetes.io/instance: keycloak
    app.kubernetes.io/version: "26.4.2"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: azure-application-gateway
  rules:
    - host: "keycloak.domain.com"
      http:
        paths:
          - path: "/"
            pathType: Prefix
            backend:
              service:
                name: keycloak-http
                port:
                  name: http
```

This fix allows us to completely bypass the tls section on ingress by removing the default values.

I also bumped the chart version by incrementing the number assigned to the fix, from `7.1.4` to `7.1.5`.