### PR TITLE
Use with function to wrap imagePullSecrets in serviceaccount.yaml

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloakx
-version: 7.1.5
+version: 7.1.6
 appVersion: 26.4.5
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:

--- a/charts/keycloakx/templates/serviceaccount.yaml
+++ b/charts/keycloakx/templates/serviceaccount.yaml
@@ -15,8 +15,10 @@ metadata:
     {{- range $key, $value := .Values.serviceAccount.labels }}
     {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
     {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml .Values.serviceAccount.imagePullSecrets | nindent 4 }}
+{{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 
 ---


### PR DESCRIPTION
When using an operator to inject _imagePullSecrets_ into deployed Kubernetes resources, instead of configuring them with values and running a `helm upgrade ...` later on, a conflict arises.

The chart produces `imagePullSecrets: []` when none are set. To avoid this, simply wrap in a `with` clause like it is already done in deployment.yaml and statefulset.yaml.

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
