### PR TITLE
feat: support tag@digest format

### DIFF
--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
         - name: keycloak
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}{{- if (.Values.image.digest) -}}@{{ .Values.image.digest }}{{- else -}}:{{ .Values.image.tag | default .Chart.AppVersion }} {{- end }}"
+          image: {{ include "keycloak.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.command }}
           command:


### PR DESCRIPTION
This PR adds support for the `tag@digest` format in the `image.tag` field, enabling compatibility with dependency update tools like Renovate or Dependabot.

## Motivation

Renovate and Dependabot can pin container images by digest while preserving the tag for readability. They use the format `tag@digest` (e.g., 26.5.3@sha256:abc123...). This provides both:
- Version visibility: The tag remains human-readable
- Immutability: The digest ensures the exact image is always pulled

Current chart fails with this format because `image.tag` is used in the `app.kubernetes.io/version` label:
```yaml
app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | ... }}
```
The `@` character is invalid in Kubernetes labels, causing deployment to fail:

> Error from server (Invalid): metadata.labels: Invalid value: "26.5.2@sha256:abc123": 
a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', 
and must start and end with an alphanumeric character

The chart already supports a separate `image.digest` field, but using tag + digest together is mutually exclusive.

## Changes

Added a `keycloak.imageVersion` helper that extracts the version part (before `@`) for use in labels. This ensures:
- Labels remain valid (no `@` character)
- The label reflects the actual image tag being deployed
- Backward compatibility