### PR TITLE
Bump busybox image to 1.37 for dbchecker initcontainer

### DIFF
--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -440,7 +440,7 @@ dbchecker:
     # Docker image used to check Database readiness at startup
     repository: docker.io/busybox
     # Image tag for the dbchecker image
-    tag: 1.32
+    tag: 1.37
     # Image pull policy for the dbchecker image
     pullPolicy: IfNotPresent
   # SecurityContext for the dbchecker container


### PR DESCRIPTION
- Updates the busybox image used by the `dbchecker` init container from `1.32` to `1.37`. 
- `1.32` was released in early 2021 and is nearly 5 years old