### PR TITLE
Update Keycloak to 26.5.5

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 7.1.8
-appVersion: 26.5.3
+version: 7.1.9
+appVersion: 26.5.5
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.5.3
+FROM quay.io/keycloak/keycloak:26.5.5
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.5.3"
+  tag: "26.5.5"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
Security-patch to update Keycloak to 26.5.5

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
