### PR TITLE
fix(keycloakx): Include labels in headless service

### DIFF
--- a/charts/keycloakx/templates/service-headless.yaml
+++ b/charts/keycloakx/templates/service-headless.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.serviceHeadless.labels }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/component: headless
 spec:
   type: ClusterIP

--- a/charts/keycloakx/values.schema.json
+++ b/charts/keycloakx/values.schema.json
@@ -494,6 +494,9 @@
           },
           "extraPorts": {
             "type": "array"
+          },
+          "labels": {
+            "type": "object"
           }
         }
       },

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -246,7 +246,7 @@ secrets: {}
 service:
   # Annotations for HTTP service
   annotations: {}
-  # Additional labels for headless and HTTP Services
+  # Additional labels for HTTP Service
   labels: {}
   # key: value
   # The Service type
@@ -280,6 +280,8 @@ service:
 serviceHeadless:
   # Annotations for headless service
   annotations: {}
+  # Additional labels for headless service
+  labels: {}
   # Add additional ports to the headless service, e. g. for admin console or exposing JGroups ports
   extraPorts: []
 


### PR DESCRIPTION
Fixes #892

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
