### PR TITLE
ci: Fix chart-dirs property to correctly pick up changes made to

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,10 @@
 remote: origin
 target-branch: master
 chart-dirs:
-  - charts/keycloakx
+  - charts
+excluded-charts:
+  - keycloak
+  - mailhog
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 check-version-increment: false


### PR DESCRIPTION
Fixes #894

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
