### PR TITLE
 fix(keycloakx): replace archived seleniarm image in Helm

### DIFF
--- a/charts/keycloakx/templates/test/configmap-test.yaml
+++ b/charts/keycloakx/templates/test/configmap-test.yaml
@@ -14,23 +14,14 @@ data:
     #!/usr/bin/env bash
     set -eu
 
-    if ! python3 -c 'import selenium' &> /dev/null
-    then
-      if ! command -v pip3 &> /dev/null
-      then
-        echo 'Installing pip3...'
-        export PATH="$PATH:$HOME/.local/bin"
-        mkdir -p "$HOME/.config/pip"
-        echo -e '[global]\nbreak-system-packages = true' > "$HOME/.config/pip/pip.conf"
-        wget -q -P "$HOME" https://bootstrap.pypa.io/get-pip.py
-        python3 "$HOME/get-pip.py" --user 1> /dev/null
-      fi
-
+    if ! python3 -c 'import selenium' &> /dev/null; then
       echo 'Installing selenium module...'
-      pip3 -q install selenium
+      python3 -m venv /tmp/test-venv
+      /tmp/test-venv/bin/pip install -q selenium
+      exec /tmp/test-venv/bin/python "$(dirname "$0")/test.py"
     fi
 
-    python3 "$(dirname $0)/test.py"
+    python3 "$(dirname "$0")/test.py"
   test.py: |
     import os
     from selenium import webdriver

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -616,17 +616,17 @@ test:
   enabled: false
   image:
     # The image for the test Pod
-    repository: docker.io/seleniarm/standalone-chromium
+    repository: docker.io/selenium/standalone-chromium
     # The tag for the test Pod image
-    tag: "117.0"
+    tag: "147.0"
     # The image pull policy for the test Pod image
     pullPolicy: IfNotPresent
   # SecurityContext for the entire test Pod
   podSecurityContext:
-    fsGroup: 1000
+    fsGroup: 1200  # UID of seluser in selenium/standalone-chromium
   # SecurityContext for the test container
   securityContext:
-    runAsUser: 1000
+    runAsUser: 1200  # UID of seluser in selenium/standalone-chromium
     runAsNonRoot: true
   # See https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies
   deletionPolicy: before-hook-creation


### PR DESCRIPTION
 The seleniarm project was archived in 2024. Switch to the selenium/standalone-chromium image (SeleniumHQ absorbed seleniarm's
  multi-arch work), bumping Chromium from 117.0 to 147.0.

<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
