### PR TITLE
fix(keycloakx): preserve YAML document separators in templates

### DIFF
--- a/charts/keycloakx/templates/httproute.yaml
+++ b/charts/keycloakx/templates/httproute.yaml
@@ -47,7 +47,7 @@ spec:
     {{- end }}
 {{- end }}
 ---
-{{- if $httpRoute.console.enabled -}}
+{{- if $httpRoute.console.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/keycloakx/templates/serviceaccount.yaml
+++ b/charts/keycloakx/templates/serviceaccount.yaml
@@ -20,9 +20,8 @@ imagePullSecrets: {{ toYaml . | nindent 4 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 
+{{- if .Values.serviceAccount.allowReadPods }}
 ---
-
-  {{- if .Values.serviceAccount.allowReadPods -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -44,5 +43,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "keycloak.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-  {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #900 

I checked the whole repo and found only these two instances of this specific linting error.