### PR TITLE
Update Keycloak to 26.6.2, bump chart to 7.2.0

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 7.1.11
-appVersion: 26.5.6
+version: 7.2.0
+appVersion: 26.6.2
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.5.6
+FROM quay.io/keycloak/keycloak:26.6.2
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.5.6"
+  tag: "26.6.2"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
## Summary

- Update Keycloak from 26.5.6 to 26.6.2
- Bump chart version from 7.1.11 to 7.2.0 (minor bump due to Keycloak minor version jump with breaking changes)

## Changes

- `charts/keycloakx/Chart.yaml` — version 7.2.0, appVersion 26.6.2
- `charts/keycloakx/values.yaml` — image tag 26.6.2
- `charts/keycloakx/examples/postgresql-kubeping/Dockerfile` — FROM tag 26.6.2

## Breaking changes analysis

All breaking changes in 26.6.0/26.6.1/26.6.2 are at the application/client configuration level. No Helm chart template changes required — probes, ports, and services are already compatible. See [#902 comment](https://github.com/codecentric/helm-charts/issues/902#issuecomment-4516696099) for a detailed breakdown.

Users should review the upgrade guides before upgrading:
- [Migrating to 26.6.0](https://www.keycloak.org/docs/26.6.2/upgrading/#migrating-to-26-6-0)
- [Migrating to 26.6.1](https://www.keycloak.org/docs/26.6.2/upgrading/#migrating-to-26-6-1)
- [Migrating to 26.6.2](https://www.keycloak.org/docs/26.6.2/upgrading/#migrating-to-26-6-2)

Closes #902