### PR TITLE
feature - add gatewayapi support in mailhog

### DIFF
--- a/charts/mailhog/Chart.yaml
+++ b/charts/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: v1.0.1
-version: 5.8.0
+version: 5.9.0
 type: application
 keywords:
   - mailhog

--- a/charts/mailhog/values.yaml
+++ b/charts/mailhog/values.yaml
@@ -71,14 +71,23 @@ ingress:
   hosts:
     - host: mailhog.example.com
       paths:
-        - path: "/"
+        - path: /
           pathType: Prefix
 
-
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+gatewayapi:
+  enabled: false
+  gateway:
+    name: envoy-gateway 
+    namespace: ""       # defaults to Release.Namespace if omitted
+    httpPort: 80        # optional, default 80
+    httpsPort: 443      # optional, default 443
+  labels: {}
+  annotations: {}
+  hosts:
+    - host: mailhog.example.com
+      paths:
+        - path: /
+          pathType: PathPrefix
 
 auth:
   enabled: false


### PR DESCRIPTION
<!---
Thanks for wanting to contribute.

Manual updates to the chart version are not needed any more. The version bumps are now based on commit messages. If you want to bump the major version include `major` in the commit message. For a feature release, include `feature` or `feat`. If you don't want to create a new release at all, include `chore` in all your commit messages. The default is a new patch release. For the specific keywords have a look at [the script](scripts/bump-version.py).
--->
