### PR TITLE
Update Keycloak to 26.6.3, bump chart to 7.2.1

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 7.2.0
-appVersion: 26.6.2
+version: 7.2.1
+appVersion: 26.6.3
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.6.2
+FROM quay.io/keycloak/keycloak:26.6.3
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.6.2"
+  tag: "26.6.3"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
Bumps Keycloak.X to 26.6.3 and the keycloakx chart to 7.2.1.

## Changes
- `charts/keycloakx/Chart.yaml`: `appVersion` 26.6.2 → 26.6.3, `version` 7.2.0 → 7.2.1
- `charts/keycloakx/values.yaml`: image `tag` 26.6.2 → 26.6.3
- `charts/keycloakx/examples/postgresql-kubeping/Dockerfile`: base image 26.6.2 → 26.6.3

Keycloak 26.6.3 is published on quay.io/keycloak/keycloak (released 2026-06-04). Follows the same pattern as #903.