### PR TITLE
feat(keycloakx): add namespaceOverride and service.internalTrafficPolicy

### DIFF
--- a/charts/keycloakx/templates/NOTES.txt
+++ b/charts/keycloakx/templates/NOTES.txt
@@ -19,15 +19,15 @@ Keycloak was installed with a Service of type NodePort.
 {{ if .Values.service.httpNodePort }}
 Get its HTTP URL with the following commands:
 
-export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} service {{ include "keycloak.fullname" . }}-http --template='{{"{{ range .spec.ports }}{{ if eq .name \"http\" }}{{ .nodePort }}{{ end }}{{ end }}"}}')
-export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+export NODE_PORT=$(kubectl get --namespace {{ include "keycloakx.namespace" . }} service {{ include "keycloak.fullname" . }}-http --template='{{"{{ range .spec.ports }}{{ if eq .name \"http\" }}{{ .nodePort }}{{ end }}{{ end }}"}}')
+export NODE_IP=$(kubectl get nodes --namespace {{ include "keycloakx.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
 echo "http://$NODE_IP:$NODE_PORT"
 {{- end }}
 {{ if .Values.service.httpsNodePort }}
 Get its HTTPS URL with the following commands:
 
-export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} service {{ include "keycloak.fullname" . }}-http --template='{{"{{ range .spec.ports }}{{ if eq .name \"https\" }}{{ .nodePort }}{{ end }}{{ end }}"}}')
-export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+export NODE_PORT=$(kubectl get --namespace {{ include "keycloakx.namespace" . }} service {{ include "keycloak.fullname" . }}-http --template='{{"{{ range .spec.ports }}{{ if eq .name \"https\" }}{{ .nodePort }}{{ end }}{{ end }}"}}')
+export NODE_IP=$(kubectl get nodes --namespace {{ include "keycloakx.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
 echo "http://$NODE_IP:$NODE_PORT"
 {{- end }}
 
@@ -36,16 +36,16 @@ echo "http://$NODE_IP:$NODE_PORT"
 Keycloak was installed with a Service of type LoadBalancer
 
 NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-     You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} service -w {{ include "keycloak.fullname" . }}'
+     You can watch the status of by running 'kubectl get --namespace {{ include "keycloakx.namespace" . }} service -w {{ include "keycloak.fullname" . }}'
 
 Get its HTTP URL with the following commands:
 
-export SERVICE_IP=$(kubectl get service --namespace {{ .Release.Namespace }} {{ include "keycloak.fullname" . }}-http --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+export SERVICE_IP=$(kubectl get service --namespace {{ include "keycloakx.namespace" . }} {{ include "keycloak.fullname" . }}-http --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
 echo "http://$SERVICE_IP:{{ .Values.service.httpPort }}"
 
 Get its HTTPS URL with the following commands:
 
-export SERVICE_IP=$(kubectl get service --namespace {{ .Release.Namespace }} {{ include "keycloak.fullname" . }}-http --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+export SERVICE_IP=$(kubectl get service --namespace {{ include "keycloakx.namespace" . }} {{ include "keycloak.fullname" . }}-http --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
 echo "http://$SERVICE_IP:{{ .Values.service.httpsPort }}"
 
 {{- else if eq "ClusterIP" .Values.service.type }}
@@ -54,8 +54,8 @@ Keycloak was installed with a Service of type ClusterIP
 
 Create a port-forwarding with the following commands:
 
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "keycloak.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o name)
+export POD_NAME=$(kubectl get pods --namespace {{ include "keycloakx.namespace" . }} -l "app.kubernetes.io/name={{ include "keycloak.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o name)
 echo "Visit http://127.0.0.1:8080 to use your application"
-kubectl --namespace {{ .Release.Namespace }} port-forward "$POD_NAME" 8080
+kubectl --namespace {{ include "keycloakx.namespace" . }} port-forward "$POD_NAME" 8080
 
 {{- end }}

--- a/charts/keycloakx/templates/_helpers.tpl
+++ b/charts/keycloakx/templates/_helpers.tpl
@@ -62,7 +62,14 @@ Create the name of the service account to use
 Create the service DNS name.
 */}}
 {{- define "keycloak.serviceDnsName" -}}
-{{ include "keycloak.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+{{ include "keycloak.fullname" . }}-headless.{{ include "keycloakx.namespace" . }}.svc.{{ .Values.clusterDomain }}
+{{- end }}
+
+{{/*
+Namespace for all resources. Callers can override via .Values.namespaceOverride.
+*/}}
+{{- define "keycloakx.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
 {{- end }}
 
 {{- define "keycloak.databasePasswordEnv" -}}

--- a/charts/keycloakx/templates/configmap-startup.yaml
+++ b/charts/keycloakx/templates/configmap-startup.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "keycloak.fullname" . }}-startup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 data:

--- a/charts/keycloakx/templates/database-secret.yaml
+++ b/charts/keycloakx/templates/database-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "keycloak.fullname" $ }}-database
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
   {{- include "keycloak.labels" $ | nindent 4 }}
 type: Opaque

--- a/charts/keycloakx/templates/hpa.yaml
+++ b/charts/keycloakx/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.autoscaling.labels }}

--- a/charts/keycloakx/templates/httproute.yaml
+++ b/charts/keycloakx/templates/httproute.yaml
@@ -4,7 +4,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
     {{- range $key, $value := $httpRoute.labels }}
@@ -52,7 +52,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "keycloak.fullname" . }}-console
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
     {{- range $key, $value := $httpRoute.labels }}

--- a/charts/keycloakx/templates/ingress.yaml
+++ b/charts/keycloakx/templates/ingress.yaml
@@ -6,7 +6,7 @@ apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   {{- with $ingress.annotations }}
   annotations:
     {{- range $key, $value := . }}
@@ -55,7 +55,7 @@ apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-console
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   {{- with $ingress.console.annotations }}
   annotations:
     {{- range $key, $value := . }}

--- a/charts/keycloakx/templates/networkpolicy.yaml
+++ b/charts/keycloakx/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "keycloak.fullname" . | quote }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.networkPolicy.labels }}

--- a/charts/keycloakx/templates/poddisruptionbudget.yaml
+++ b/charts/keycloakx/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" 
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 spec:

--- a/charts/keycloakx/templates/prometheusrule.yaml
+++ b/charts/keycloakx/templates/prometheusrule.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- with .namespace }}
   namespace: {{ . }}
   {{- else }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" $ }}
   {{- end }}
   {{- with .annotations }}
   annotations:

--- a/charts/keycloakx/templates/rbac.yaml
+++ b/charts/keycloakx/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 rules:
@@ -13,7 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 roleRef:
@@ -23,5 +23,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "keycloak.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "keycloakx.namespace" . | quote }}
 {{- end }}

--- a/charts/keycloakx/templates/route.yaml
+++ b/charts/keycloakx/templates/route.yaml
@@ -4,7 +4,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   {{- with $route.annotations }}
   annotations:
     {{- range $key, $value := . }}

--- a/charts/keycloakx/templates/secrets.yaml
+++ b/charts/keycloakx/templates/secrets.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "keycloak.fullname" $ }}-{{ $nameSuffix }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" $ }}
   {{- with $values.annotations }}
   annotations:
   {{- range $key, $value := . }}

--- a/charts/keycloakx/templates/service-headless.yaml
+++ b/charts/keycloakx/templates/service-headless.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keycloak.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   {{- with .Values.serviceHeadless.annotations }}
   annotations:
     {{- range $key, $value := . }}

--- a/charts/keycloakx/templates/service-http.yaml
+++ b/charts/keycloakx/templates/service-http.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keycloak.fullname" . }}-http
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- range $key, $value := . }}
@@ -26,6 +26,9 @@ spec:
   {{- end }}
   {{- if or (eq "LoadBalancer" .Values.service.type) (eq "NodePort" .Values.service.type) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
   {{- end }}
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}

--- a/charts/keycloakx/templates/serviceaccount.yaml
+++ b/charts/keycloakx/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "keycloak.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- range $key, $value := . }}
@@ -25,7 +25,7 @@ automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountT
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jgroups-kubeping-pod-reader-{{ .Release.Namespace }}
+  name: jgroups-kubeping-pod-reader-{{ include "keycloakx.namespace" . }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -34,14 +34,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: jgroups-kubeping-api-access-{{ .Release.Namespace }}
+  name: jgroups-kubeping-api-access-{{ include "keycloakx.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: jgroups-kubeping-pod-reader-{{ .Release.Namespace }}
+  name: jgroups-kubeping-pod-reader-{{ include "keycloakx.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "keycloak.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "keycloakx.namespace" . }}
 {{- end }}
 {{- end }}

--- a/charts/keycloakx/templates/servicemonitor.yaml
+++ b/charts/keycloakx/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- with .namespace }}
   namespace: {{ . }}
   {{- else }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" $ }}
   {{- end }}
   {{- with .annotations }}
   annotations:

--- a/charts/keycloakx/templates/statefulset.yaml
+++ b/charts/keycloakx/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   {{- with .Values.statefulsetAnnotations }}
   annotations:
     {{- range $key, $value := . }}

--- a/charts/keycloakx/templates/test/configmap-test.yaml
+++ b/charts/keycloakx/templates/test/configmap-test.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "keycloak.fullname" . }}-test
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   annotations:

--- a/charts/keycloakx/templates/test/pod-test.yaml
+++ b/charts/keycloakx/templates/test/pod-test.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "keycloak.fullname" . }}-test
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloakx.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
     app.kubernetes.io/component: test

--- a/charts/keycloakx/values.schema.json
+++ b/charts/keycloakx/values.schema.json
@@ -245,6 +245,9 @@
       "nameOverride": {
         "type": "string"
       },
+      "namespaceOverride": {
+        "type": "string"
+      },
       "nodeSelector": {
         "type": "object"
       },
@@ -476,6 +479,9 @@
             "type": "string"
           },
           "loadBalancerIP": {
+            "type": "string"
+          },
+          "internalTrafficPolicy": {
             "type": "string"
           },
           "sessionAffinity": {

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -4,6 +4,10 @@ fullnameOverride: ""
 # Optionally override the name
 nameOverride: ""
 
+# Optionally override the namespace for all resources. Useful for umbrella charts that
+# deploy multiple aliased keycloakx instances each into their own namespace.
+namespaceOverride: ""
+
 # The number of replicas to create (has no effect if autoscaling enabled)
 replicas: 1
 
@@ -271,6 +275,9 @@ service:
   # by changing the default (Cluster) to be Local.
   # See https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   externalTrafficPolicy: "Cluster"
+  # Controls how traffic from internal sources is routed. Valid values: Cluster, Local.
+  # See https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+  internalTrafficPolicy: ""
   # Session affinity
   # See https://kubernetes.io/docs/concepts/services-networking/service/#proxy-mode-userspace
   sessionAffinity: ""


### PR DESCRIPTION
## Summary

- Adds \`namespaceOverride\` value so umbrella charts can deploy multiple aliased keycloakx instances each into their own namespace. A \`keycloakx.namespace\` helper centralises the logic; all templates use it instead of \`.Release.Namespace\` directly.
- Adds \`service.internalTrafficPolicy\` to \`values.yaml\` and \`service-http.yaml\`. Previously there was no way to set this field without a post-renderer workaround.

## Motivation

When deploying keycloakx as a subchart multiple times in the same umbrella chart (using Helm aliases), all instances land in the release namespace. \`namespaceOverride\` lets each alias target a different namespace independently.

\`internalTrafficPolicy\` is needed to control routing for internal cluster traffic (e.g. \`Local\` to keep traffic node-local), which is a standard Kubernetes Service field not currently exposed by the chart.

## Backwards compatibility

Both changes are additive. Default values (\`namespaceOverride: ""\`, \`internalTrafficPolicy: ""\`) preserve existing behaviour — charts that don't set these values render identically to before.