### PR TITLE
Update Keycloak to 26.6.4, bump chart to 7.2.2

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 7.2.1
-appVersion: 26.6.3
+version: 7.2.2
+appVersion: 26.6.4
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.6.3
+FROM quay.io/keycloak/keycloak:26.6.4
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -11,7 +11,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.6.3"
+  tag: "26.6.4"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
Bumps the keycloakx chart to Keycloak 26.6.4 and chart version 7.2.2.

- `charts/keycloakx/Chart.yaml`: `appVersion` 26.6.3 → 26.6.4, `version` 7.2.1 → 7.2.2
- `charts/keycloakx/values.yaml`: image `tag` 26.6.3 → 26.6.4
- `charts/keycloakx/examples/postgresql-kubeping/Dockerfile`: base image 26.6.3 → 26.6.4

Same pattern as #907.