### PR TITLE
Keycloakx add missing trimsuffix

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloakx
-version: 7.2.2
+version: 7.2.3
 appVersion: 26.6.4
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:

--- a/charts/keycloakx/templates/_helpers.tpl
+++ b/charts/keycloakx/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Common labels
 {{- define "keycloak.labels" -}}
 helm.sh/chart: {{ include "keycloak.chart" . }}
 {{ include "keycloak.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | toString | trunc 63 | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | toString | trunc 63 | trimSuffix "-" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $key, $value := .Values.commonLabels }}
 {{ printf "%s: %s" $key (tpl $value $ | quote) }}


### PR DESCRIPTION
Patched the keycloakx helm chart in order to avoid templating errors, if the docker image.tag is longer than 63 chars and after truncating the remaining string contains a dash "-" at the end. 
