### PR TITLE
Update Keycloak to 26.7.2, bump chart to 7.3.0

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 7.2.3
-appVersion: 26.6.4
+version: 7.3.0
+appVersion: 26.7.2
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.6.4
+FROM quay.io/keycloak/keycloak:26.7.2
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -18,7 +18,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.6.4"
+  tag: "26.7.2"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
Updates the keycloakx chart to Keycloak 26.7.2 (released 2026-08-19).

Chart version 7.2.3 -> 7.3.0. Minor bump to match the Keycloak minor bump,
following 26.5.6 -> 26.6.2 which moved the chart 7.1.11 -> 7.2.0.

### Changes

- `charts/keycloakx/Chart.yaml`: `version` 7.2.3 -> 7.3.0, `appVersion` 26.6.4 -> 26.7.2
- `charts/keycloakx/values.yaml`: `image.tag` 26.6.4 -> 26.7.2
- `charts/keycloakx/examples/postgresql-kubeping/Dockerfile`: base image 26.6.4 -> 26.7.2

### Testing

`helm template charts/keycloakx` renders without error.