### PR TITLE
Update Keycloak to 26.7.3, bump chart to 7.3.1

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloakx
-version: 7.3.0
-appVersion: 26.7.2
+version: 7.3.1
+appVersion: 26.7.3
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 keywords:
   - sso

--- a/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
+++ b/charts/keycloakx/examples/postgresql-kubeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.7.2
+FROM quay.io/keycloak/keycloak:26.7.3
 
 ENV JGROUPS_KUBERNETES_VERSION 1.0.16.Final
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -18,7 +18,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.7.2"
+  tag: "26.7.3"
   # Overrides the Keycloak image tag with a specific digest
   digest: ""
   # The Keycloak image pull policy


### PR DESCRIPTION
Bumps Keycloak.X to 26.7.3 and the keycloakx chart to 7.3.1.

### Changes
- `charts/keycloakx/Chart.yaml`: `appVersion` 26.7.2 → 26.7.3, `version` 7.3.0 → 7.3.1
- `charts/keycloakx/values.yaml`: image `tag` 26.7.2 → 26.7.3
- `charts/keycloakx/examples/postgresql-kubeping/Dockerfile`: base image 26.7.2 → 26.7.3

### Testing
`helm template charts/keycloakx` renders without error.

### Security fixes (CVEs)

Keycloak 26.7.3 is a patch release fixing 20 CVEs. Full details: https://www.keycloak.org/2026/08/keycloak-2673-released

- CVE-2026-35563 — LDAP client fails to verify server certificate matches intended hostname
- CVE-2026-16093 — Required signed-JWT assertion policy bypassed via unsigned assertion headers (OIDC)
- CVE-2026-16072 — Organization managers can create managed members via stored registration links
- CVE-2026-16108 — Realm default-group reads disclose hidden groups under FGAP v2
- CVE-2026-16105 — Missing per-role authorization on RoleContainerResource composite endpoints
- CVE-2026-16089 — Authorization codes can be retargeted to another client session (OIDC)
- CVE-2026-16104 — Authenticator config exposes raw reCAPTCHA secrets
- CVE-2026-16106 — Incorrect authorization in admin role-composite deletion
- CVE-2026-17059 — GET /roles/{role}/users returns user PII without view filter
- CVE-2026-18218 — Client not-before revocation ignored when realm not-before is older (OIDC)
- CVE-2026-18215 — Microsoft external access-token exchange bypasses tenant configuration
- CVE-2026-18201 — Generic identity-provider creation binds brokers to organizations
- CVE-2026-18209 — Incomplete redirect_uri OIDC injection fix; fragment not inspected
- CVE-2026-18214 — Google external access-token exchange bypasses hosted-domain restriction
- CVE-2026-18571 — FGAP V2 group assignment bypass during user creation
- CVE-2026-18572 — UMA claim token overrides authorization time-policy clock
- CVE-2026-18573 — Client access-type condition evaluates against old client type
- CVE-2026-18570 — Full-scope-disabled client policy bypassed by omitting fullScopeAllowed
- CVE-2026-19729 — Incomplete fix for path traversal; filesystem probing still possible
- CVE-2026-79652 — JWT-bearer grant doesn't enforce consentRequired (OIDC)

Also includes non-CVE fixes: CPU performance regressions (#51523), admin API cost growth (#51554), and SAML ECP client existence disclosure (#52017).

cc @dominiquemetz @jenslehnhoff @stefangries — could one of you take a look? Following the same pattern as #921/#911/#907.
