### PR TITLE
fix(keycloakx): HTTPRoute + ListenerSet honor namespaceOverride; console attaches to ListenerSet

### DIFF
--- a/charts/keycloakx/templates/httproute.yaml
+++ b/charts/keycloakx/templates/httproute.yaml
@@ -19,7 +19,7 @@ spec:
     {{- if $httpRoute.listenerSet.enabled }}
     - kind: ListenerSet
       name: {{ include "keycloak.fullname" $ }}
-      namespace: {{ $.Release.Namespace }}
+      namespace: {{ include "keycloak.namespace" $ }}
     {{- else }}
     {{- with $httpRoute.parentRefs }}
       {{- toYaml . | nindent 4 }}
@@ -86,12 +86,31 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-      {{- with pluck "parentRefs" $httpRoute.console $httpRoute | first }}
-      {{- toYaml . | nindent 4 }}
+    {{- if $httpRoute.listenerSet.enabled }}
+    - kind: ListenerSet
+      name: {{ include "keycloak.fullname" $ }}
+      namespace: {{ include "keycloak.namespace" $ }}
+    {{- else }}
+    {{- with pluck "parentRefs" $httpRoute.console $httpRoute | first }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- end }}
+  {{- if $httpRoute.listenerSet.enabled }}
+  {{- $hostnames := list }}
+  {{- range $httpRoute.listenerSet.listeners }}
+  {{- if .hostname }}
+  {{- $hostnames = append $hostnames .hostname }}
+  {{- end }}
+  {{- end }}
+  {{- with $hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   {{- with pluck "hostnames" $httpRoute.console $httpRoute | first }}
   hostnames:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   rules:
     {{- range $httpRoute.console.rules }}

--- a/charts/keycloakx/templates/listenerset.yaml
+++ b/charts/keycloakx/templates/listenerset.yaml
@@ -5,7 +5,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "keycloak.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
     {{- range $key, $value := $httpRoute.labels }}


### PR DESCRIPTION
### TL;DR

Three small fixes in the Gateway API templates. Two are namespace mismatches when `namespaceOverride` is set; one is the console HTTPRoute not attaching to anything in a ListenerSet-only setup.

Fixes part of #926.

### The bugs

**1. `listenerset.yaml` — namespace ignores `namespaceOverride`.** The ListenerSet's own `metadata.namespace` uses `.Release.Namespace` directly. Every other template in the chart goes through `include "keycloak.namespace"`, which honors `.Values.namespaceOverride`. Set `namespaceOverride` and the ListenerSet lands in one namespace while the HTTPRoute lands in another — nothing attaches.

**2. `httproute.yaml` main route parentRef — same bug.** When `listenerSet.enabled: true`, the main HTTPRoute's `parentRef.namespace` also resolves to `.Release.Namespace` instead of the override.

**3. `httproute.yaml` console route ignores `listenerSet.enabled`.** The main route has a `listenerSet` branch that populates `parentRefs` and `hostnames` from the listeners. The console route doesn't — it only plucks from `console.parentRefs` / `httpRoute.parentRefs` and `console.hostnames` / `httpRoute.hostnames`. In a ListenerSet-only config (where neither `parentRefs` field is set), the console route renders empty `parentRefs` and attaches to no Gateway.

Fix mirrors the main route's `listenerSet` branch into the console route.

### Verified

`helm template` with `namespaceOverride=custom-ns` + `listenerSet.enabled: true` + `console.enabled: true`:
- `HTTPRoute` main → `namespace: custom-ns`, `parentRefs[0].namespace: custom-ns` ✅
- `HTTPRoute` console → `namespace: custom-ns`, `parentRefs[0].namespace: custom-ns`, `hostnames` populated ✅
- `XListenerSet` → `namespace: custom-ns` ✅

`helm lint` clean.

Companion to #925 (schema fix, unrelated file).