### PR TITLE
fix(keycloakx): make top-level values.schema.json keys actually validate

### DIFF
--- a/charts/keycloakx/values.schema.json
+++ b/charts/keycloakx/values.schema.json
@@ -77,7 +77,7 @@
           "type": "string"
         },
         "tag": {
-          "type": ["string", "integer"]
+          "type": ["string", "integer", "number"]
         },
         "digest": {
           "type": "string"
@@ -146,10 +146,13 @@
       "type": "array"
     },
     "http": {
-      "relativePath": "string",
-      "managementRelativePath": "string",
-      "internalPort": "string",
-      "internalScheme": "string"
+      "type": "object",
+      "properties": {
+        "relativePath": { "type": "string" },
+        "managementRelativePath": { "type": "string" },
+        "internalPort": { "type": ["string", "integer"] },
+        "internalScheme": { "type": "string" }
+      }
     },
     "httpRoute": {
       "allOf": [
@@ -270,366 +273,366 @@
             }
           }
         }
-      },
-      "lifecycleHooks": {
-        "type": "string"
-      },
-      "livenessProbe": {
-        "type": "string"
-      },
-      "nameOverride": {
-        "type": "string"
-      },
-      "namespaceOverride": {
-        "type": "string"
-      },
-      "nodeSelector": {
-        "type": "object"
-      },
-      "dbchecker": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          },
-          "image": {
-            "$ref": "#/definitions/image"
-          },
-          "resources": {
-            "type": "object",
-            "properties": {
-              "limits": {
-                "type": "object",
-                "properties": {
-                  "cpu": {
-                    "type": "string"
-                  },
-                  "memory": {
-                    "type": "string"
-                  }
+      }
+    },
+    "lifecycleHooks": {
+      "type": "string"
+    },
+    "livenessProbe": {
+      "type": "string"
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "dbchecker": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
                 }
-              },
-              "requests": {
-                "type": "object",
-                "properties": {
-                  "cpu": {
-                    "type": "string"
-                  },
-                  "memory": {
-                    "type": "string"
-                  }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
                 }
               }
             }
-          },
-          "securityContext": {
-            "type": "object"
           }
+        },
+        "securityContext": {
+          "type": "object"
         }
-      },
-      "podAnnotations": {
-        "type": "object"
-      },
-      "podDisruptionBudget": {
-        "type": "object"
-      },
-      "podLabels": {
-        "type": "object"
-      },
-      "podManagementPolicy": {
-        "type": "string"
-      },
-      "updateStrategy": {
-        "type": "string"
-      },
-      "podSecurityContext": {
-        "type": "object"
-      },
-      "cache": {
-        "type": "object",
-        "properties": {
-          "stack": {
-            "type": "string"
-          }
-        }
-      },
-      "proxy": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          },
-          "mode": {
-            "type": "string"
-          }
-        }
-      },
-      "metrics": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          }
-        }
-      },
-      "health": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          }
-        }
-      },
-      "database": {
-        "type": "object",
-        "properties": {
-          "vendor": {
-            "type": "string"
-          },
-          "hostname": {
-            "type": "string"
-          },
-          "port": {
-            "type": "integer"
-          },
-          "username": {
-            "type": "string"
-          },
-          "password": {
-            "type": "string"
-          },
-          "database": {
-            "type": "string"
-          },
-          "existingSecret": {
-            "type": "string"
-          }
-        }
-      },
-      "priorityClassName": {
-        "type": "string"
-      },
-      "prometheusRule": {
-        "type": "object"
-      },
-      "serviceMonitor": {
-        "type": "object"
-      },
-      "extraServiceMonitor": {
-        "type": "object"
-      },
-      "readinessProbe": {
-        "type": "string"
-      },
-      "replicas": {
-        "type": "integer"
-      },
-      "resources": {
-        "type": "object"
-      },
-      "restartPolicy": {
-        "type": "string"
-      },
-      "route": {
-        "type": "object",
-        "properties": {
-          "annotations": {
-            "type": "object"
-          },
-          "enabled": {
-            "type": "boolean"
-          },
-          "host": {
-            "type": "string"
-          },
-          "labels": {
-            "type": "object"
-          },
-          "path": {
-            "type": "string"
-          },
-          "tls": {
-            "type": "object"
-          }
-        }
-      },
-      "secrets": {
-        "type": "object"
-      },
-      "securityContext": {
-        "type": "object"
-      },
-      "service": {
-        "type": "object",
-        "properties": {
-          "annotations": {
-            "type": "object"
-          },
-          "extraPorts": {
-            "type": "array"
-          },
-          "loadBalancerSourceRanges": {
-            "type": "array"
-          },
-          "httpNodePort": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "httpPort": {
-            "type": "integer"
-          },
-          "httpsNodePort": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "httpsPort": {
-            "type": "integer"
-          },
-          "labels": {
-            "type": "object"
-          },
-          "nodePort": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string"
-          },
-          "loadBalancerIP": {
-            "type": "string"
-          },
-          "internalTrafficPolicy": {
-            "type": "string"
-          },
-          "sessionAffinity": {
-            "type": "string"
-          },
-          "sessionAffinityConfig": {
-            "type": "object"
-          }
-        }
-      },
-      "serviceHeadless": {
-        "type": "object",
-        "properties": {
-          "annotations": {
-            "type": "object"
-          },
-          "extraPorts": {
-            "type": "array"
-          },
-          "labels": {
-            "type": "object"
-          }
-        }
-      },
-      "serviceAccount": {
-        "type": "object",
-        "properties": {
-          "annotations": {
-            "type": "object"
-          },
-          "create": {
-            "type": "boolean"
-          },
-          "allowReadPods": {
-            "type": "boolean"
-          },
-          "imagePullSecrets": {
-            "$ref": "#/definitions/imagePullSecrets"
-          },
-          "labels": {
-            "type": "object"
-          },
-          "name": {
-            "type": "string"
-          },
-          "automountServiceAccountToken": {
-            "type": "boolean"
-          }
-        }
-      },
-      "rbac": {
-        "type": "object",
-        "properties": {
-          "create": {
-            "type": "boolean"
-          },
-          "rules": {
-            "type": "array"
-          }
-        }
-      },
-      "statefulsetAnnotations": {
-        "type": "object"
-      },
-      "statefulsetLabels": {
-        "type": "object"
-      },
-      "terminationGracePeriodSeconds": {
-        "type": "integer"
-      },
-      "autoscaling": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          },
-          "labels": {
-            "type": "object"
-          },
-          "minReplicas": {
-            "type": "integer"
-          },
-          "maxReplicas": {
-            "type": "integer"
-          },
-          "metrics": {
-            "type": "array"
-          },
-          "behavior": {
-            "type": "object"
-          }
-        }
-      },
-      "test": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          },
-          "image": {
-            "$ref": "#/definitions/image"
-          },
-          "podSecurityContext": {
-            "type": "object"
-          },
-          "securityContext": {
-            "type": "object"
-          }
-        }
-      },
-      "tolerations": {
-        "type": "array"
       }
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podDisruptionBudget": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podManagementPolicy": {
+      "type": "string"
+    },
+    "updateStrategy": {
+      "type": "string"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "cache": {
+      "type": "object",
+      "properties": {
+        "stack": {
+          "type": "string"
+        }
+      }
+    },
+    "proxy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "mode": {
+          "type": "string"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "health": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "type": ["string", "null"]
+        },
+        "hostname": {
+          "type": ["string", "null"]
+        },
+        "port": {
+          "type": ["integer", "null"]
+        },
+        "username": {
+          "type": ["string", "null"]
+        },
+        "password": {
+          "type": ["string", "null"]
+        },
+        "database": {
+          "type": ["string", "null"]
+        },
+        "existingSecret": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "prometheusRule": {
+      "type": "object"
+    },
+    "serviceMonitor": {
+      "type": "object"
+    },
+    "extraServiceMonitor": {
+      "type": "object"
+    },
+    "readinessProbe": {
+      "type": "string"
+    },
+    "replicas": {
+      "type": "integer"
+    },
+    "resources": {
+      "type": "object"
+    },
+    "restartPolicy": {
+      "type": "string"
+    },
+    "route": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "host": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "path": {
+          "type": "string"
+        },
+        "tls": {
+          "type": "object"
+        }
+      }
+    },
+    "secrets": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "extraPorts": {
+          "type": "array"
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array"
+        },
+        "httpNodePort": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "httpPort": {
+          "type": "integer"
+        },
+        "httpsNodePort": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "httpsPort": {
+          "type": "integer"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "nodePort": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "type": "string"
+        },
+        "loadBalancerIP": {
+          "type": "string"
+        },
+        "internalTrafficPolicy": {
+          "type": "string"
+        },
+        "sessionAffinity": {
+          "type": "string"
+        },
+        "sessionAffinityConfig": {
+          "type": "object"
+        }
+      }
+    },
+    "serviceHeadless": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "extraPorts": {
+          "type": "array"
+        },
+        "labels": {
+          "type": "object"
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "allowReadPods": {
+          "type": "boolean"
+        },
+        "imagePullSecrets": {
+          "$ref": "#/definitions/imagePullSecrets"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "rules": {
+          "type": "array"
+        }
+      }
+    },
+    "statefulsetAnnotations": {
+      "type": "object"
+    },
+    "statefulsetLabels": {
+      "type": "object"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer"
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "minReplicas": {
+          "type": "integer"
+        },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "metrics": {
+          "type": "array"
+        },
+        "behavior": {
+          "type": "object"
+        }
+      }
+    },
+    "test": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "securityContext": {
+          "type": "object"
+        }
+      }
+    },
+    "tolerations": {
+      "type": "array"
     }
   }
 }


### PR DESCRIPTION
### TL;DR

About 40 top-level keys in `values.schema.json` sit at the wrong nesting depth, so they're silently ignored by JSON Schema. `replicas: "three"` passes today. This moves them back to the top-level `properties` map.

Fixes part of #926.

### What's going on

The keys ended up as siblings of `ingress.properties` inside the `ingress` object, instead of at the top-level `properties`. Since JSON Schema only validates keys declared inside a `properties` object, ~40 keys (`replicas`, `tolerations`, `resources`, `namespaceOverride`, `serviceAccount`, and so on) are treated as unknown keywords and validate nothing.

Two related things needed fixing at the same time:

- The `http` block uses literal strings like `"relativePath": "string"` instead of `{"type": "string"}` sub-schemas — same silent-ignore issue, tiny fix.
- Once the schema starts validating, two existing chart defaults trip it: `dbchecker.image.tag: 1.32` (YAML parses `1.32` as a float, so `tag` needs `number`), and `database.*` fields (null by default, need `null` alongside their real type). I loosened those types so `helm lint` passes on defaults.

### On the diff size — sorry, this one is unavoidable

Moving the 38 misplaced keys out of `ingress` means dedenting them by 2 spaces. `git diff` counts that as delete+add per line, so the raw diff is ~700 lines. **`git diff -w` shows the real change: 16 additions, 13 deletions.** No formatting reshuffling beyond the required dedent.

### Verified

- `helm lint` clean on chart defaults.
- `helm template` with `namespaceOverride=custom-ns`, `replicas=3`, and a `tolerations` array all render fine.
- Attempting `replicas: "three"` now surfaces a real schema error (previously silent).

Companion to #924 — kept separate because these edits are all in `values.schema.json` and can be reviewed on their own.